### PR TITLE
add local proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ GEMINI_API_KEY=your-key
 # RETRY_MAX_ATTEMPTS=5
 # RETRY_MAX_WAIT=60
 
+# Proxy settings (applies to all outgoing HTTP requests)
+# HR_BREAKER_PROXY=http://127.0.0.1:10808
+# HR_BREAKER_NO_PROXY=localhost,127.0.0.1
+
 # CLI options (overridden by command-line flags)
 # HR_BREAKER_OUTPUT=output
 # HR_BREAKER_MAX_ITERATIONS=5

--- a/src/hr_breaker/config.py
+++ b/src/hr_breaker/config.py
@@ -97,9 +97,35 @@ class Settings(BaseSettings):
     retry_max_attempts: int = 5
     retry_max_wait: float = 60.0
 
+    # Proxy settings (applies to all outgoing HTTP traffic)
+    proxy_url: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "HR_BREAKER_PROXY",
+            "PROXY_URL",
+            "ALL_PROXY",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+        ),
+    )
+    no_proxy: str = Field(
+        default="localhost,127.0.0.1",
+        validation_alias=AliasChoices("HR_BREAKER_NO_PROXY", "NO_PROXY"),
+    )
+
     def model_post_init(self, __context: Any) -> None:
         if self.gemini_api_key and "GEMINI_API_KEY" not in os.environ:
             os.environ["GEMINI_API_KEY"] = self.gemini_api_key
+
+        if self.proxy_url:
+            for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"):
+                if key not in os.environ and key.lower() not in os.environ:
+                    os.environ[key] = self.proxy_url
+                    os.environ[key.lower()] = self.proxy_url
+
+            if "NO_PROXY" not in os.environ and "no_proxy" not in os.environ:
+                os.environ["NO_PROXY"] = self.no_proxy
+                os.environ["no_proxy"] = self.no_proxy
 
 
 @lru_cache

--- a/src/hr_breaker/services/scrapers/httpx_scraper.py
+++ b/src/hr_breaker/services/scrapers/httpx_scraper.py
@@ -61,7 +61,7 @@ class HttpxScraper(BaseScraper):
         }
 
         with httpx.Client(
-            follow_redirects=True, timeout=self.timeout
+            follow_redirects=True, timeout=self.timeout, trust_env=True
         ) as client:
             response = client.get(url, headers=headers)
             html = response.text

--- a/src/hr_breaker/services/scrapers/playwright_scraper.py
+++ b/src/hr_breaker/services/scrapers/playwright_scraper.py
@@ -1,5 +1,7 @@
 import logging
 
+from hr_breaker.config import get_settings
+
 from .base import BaseScraper, CloudflareBlockedError, ScrapingError
 
 logger = logging.getLogger(__name__)
@@ -21,6 +23,9 @@ class PlaywrightScraper(BaseScraper):
 
     def __init__(self, timeout: float = 60000):  # ms for playwright
         self.timeout = timeout
+        settings = get_settings()
+        self.proxy_url = settings.proxy_url
+        self.proxy_bypass = settings.no_proxy
 
     def scrape(self, url: str) -> str:
         """Scrape job posting using headless browser."""
@@ -32,7 +37,13 @@ class PlaywrightScraper(BaseScraper):
 
         try:
             with sync_playwright() as p:
-                browser = p.chromium.launch(headless=True)
+                proxy_config = None
+                if self.proxy_url:
+                    proxy_config = {"server": self.proxy_url}
+                    if self.proxy_bypass:
+                        proxy_config["bypass"] = self.proxy_bypass
+
+                browser = p.chromium.launch(headless=True, proxy=proxy_config)
                 try:
                     context = browser.new_context(
                         user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "

--- a/src/hr_breaker/services/scrapers/wayback_scraper.py
+++ b/src/hr_breaker/services/scrapers/wayback_scraper.py
@@ -31,7 +31,7 @@ class WaybackScraper(BaseScraper):
         logger.info(f"Using Wayback snapshot: {snapshot_url}")
 
         with httpx.Client(
-            follow_redirects=True, timeout=self.timeout
+            follow_redirects=True, timeout=self.timeout, trust_env=True
         ) as client:
             response = client.get(snapshot_url)
             response.raise_for_status()
@@ -50,7 +50,7 @@ class WaybackScraper(BaseScraper):
         }
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, trust_env=True) as client:
                 response = client.get(WAYBACK_CDX_API, params=params)
                 response.raise_for_status()
                 data = response.json()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1271,7 +1271,7 @@ wheels = [
 
 [[package]]
 name = "hr-breaker"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
This pull request adds support for proxy configuration across all outgoing HTTP requests, making it easier to route traffic through a proxy server when needed. The changes introduce new proxy-related settings, update environment variable handling, and ensure that both HTTPX- and Playwright-based scrapers respect proxy settings.

**Proxy configuration support:**

* Added `proxy_url` and `no_proxy` fields to the `Settings` class in `src/hr_breaker/config.py`, with support for multiple environment variable aliases and default values. The settings are now automatically propagated to relevant environment variables if set.
* Updated `.env.example` to document the new proxy-related environment variables (`HR_BREAKER_PROXY` and `HR_BREAKER_NO_PROXY`).

**Scraper updates for proxy usage:**

* Modified HTTPX client usage in both `src/hr_breaker/services/scrapers/httpx_scraper.py` and `src/hr_breaker/services/scrapers/wayback_scraper.py` to set `trust_env=True`, allowing HTTPX to honor proxy environment variables. [[1]](diffhunk://#diff-a4116a0fe5bc67f0e525d41fc1ed2e747d8f04e7642a7341ae309598c2aa06c5L64-R64) [[2]](diffhunk://#diff-75495faadd0a8d99684616ced5b3ab116a0ffa01fb29943acfc2facf188bfddaL34-R34) [[3]](diffhunk://#diff-75495faadd0a8d99684616ced5b3ab116a0ffa01fb29943acfc2facf188bfddaL53-R53)
* Updated `PlaywrightScraper` in `src/hr_breaker/services/scrapers/playwright_scraper.py` to read proxy settings from the configuration and pass them to the browser launch configuration, including proxy bypass settings. [[1]](diffhunk://#diff-66796172a1e054c7c538c00a04a792fbcd947d5fae5a0d43e56e84e4e11e5488R3-R4) [[2]](diffhunk://#diff-66796172a1e054c7c538c00a04a792fbcd947d5fae5a0d43e56e84e4e11e5488R26-R28) [[3]](diffhunk://#diff-66796172a1e054c7c538c00a04a792fbcd947d5fae5a0d43e56e84e4e11e5488L35-R46)