### PR TITLE
feat(ui): profile-first resume UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,37 @@
+# LLM settings
+
+# Shared mode (default)
+# LLM_SEPARATE_MODELS=false
+# LLM_SHARED_PROVIDER=gemini                  # gemini | openai_compatible
+# LLM_SHARED_API_KEY=your-key
+# LLM_SHARED_BASE_URL=https://integrate.api.nvidia.com/v1  # used for openai_compatible only
+
 # Model config (litellm format - see https://docs.litellm.ai/docs/providers)
-# PRO_MODEL=gemini/gemini-3-pro-preview # smart model
-# PRO_MODEL=moonshot/kimi-k2-5          # Moonshot AI alternative
-# PRO_MODEL=openrouter/google/gemini-3-pro-preview # if using openrouter
+# PRO_MODEL=gemini/gemini-3-pro-preview        # smart model
+# PRO_MODEL=moonshot/kimi-k2-5                 # Moonshot AI alternative
+# PRO_MODEL=openrouter/google/gemini-3-pro-preview  # if using openrouter
+# FLASH_MODEL=gemini/gemini-3-flash-preview    # fast model
+# FLASH_MODEL=moonshot/kimi-k2-5               # Moonshot AI alternative
+# EMBEDDING_PROVIDER=gemini
+# EMBEDDING_API_KEY=your-key
+# EMBEDDING_BASE_URL=https://integrate.api.nvidia.com/v1
+# EMBEDDING_MODEL=gemini/text-embedding-004
 
-# FLASH_MODEL=gemini/gemini-3-flash-preview # fast model
-# FLASH_MODEL=moonshot/kimi-k2-5        # Moonshot AI alternative
-# EMBEDDING_MODEL=openrouter/google/gemini-embedding-001
-
-# Reasoning (none/low/medium/high)
-# REASONING_EFFORT=medium
+# Separate mode overrides (used only when LLM_SEPARATE_MODELS=true)
+# PRO_PROVIDER=gemini
+# PRO_API_KEY=your-key
+# PRO_BASE_URL=https://integrate.api.nvidia.com/v1
+# FLASH_PROVIDER=openai_compatible
+# FLASH_API_KEY=your-key
+# FLASH_BASE_URL=https://integrate.api.nvidia.com/v1
 
 # API keys (set for your provider - litellm reads from env)
 GEMINI_API_KEY=your-key
+# GOOGLE_API_KEY=your-key  # alternative to GEMINI_API_KEY (for backward compat)
 # MOONSHOT_API_KEY=your-key
 # OPENROUTER_API_KEY=your-key
 # OPENAI_API_KEY=your-key
 # ANTHROPIC_API_KEY=your-key
-
 
 # Logging
 # LOG_LEVEL=WARNING          # hr-breaker logger

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,11 @@ wheels/
 venv/
 ENV/
 
-# Environment variables
+# Environment variables and local secrets
 .env
-
+.env.*
+!.env.example
+.streamlit/secrets.toml
 # Cache
 .cache/
 
@@ -49,3 +51,4 @@ output/
 Thumbs.db
 
 
+omp-session-*.html

--- a/src/hr_breaker/agents/ai_generated_detector.py
+++ b/src/hr_breaker/agents/ai_generated_detector.py
@@ -1,4 +1,5 @@
 from datetime import date
+from functools import lru_cache
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
@@ -6,7 +7,7 @@ from pydantic_ai import Agent
 from hr_breaker.config import get_flash_model, get_model_settings
 from hr_breaker.models import FilterResult, OptimizedResume
 from hr_breaker.models.language import Language
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 
 class AIGeneratedResult(BaseModel):
@@ -70,6 +71,7 @@ When listing indicators, quote specific problematic text.
 """
 
 
+@lru_cache
 def get_ai_generated_agent() -> Agent:
     agent = Agent(
         get_flash_model(),
@@ -116,7 +118,7 @@ This resume is written in {language.english_name}. This is intentional.
 """
 
     agent = get_ai_generated_agent()
-    result = await run_with_retry(agent.run, prompt)
+    result = await run_tracked_agent(agent, prompt, component="AIGeneratedChecker")
     r = result.output
 
     issues = []

--- a/src/hr_breaker/agents/combined_reviewer.py
+++ b/src/hr_breaker/agents/combined_reviewer.py
@@ -9,7 +9,7 @@ from hr_breaker.config import get_flash_model, get_model_settings
 from hr_breaker.models import JobPosting, OptimizedResume
 from hr_breaker.models.language import Language
 from hr_breaker.services.renderer import get_renderer, RenderError
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 
 class CombinedReviewResult(BaseModel):
@@ -86,7 +86,7 @@ CHECK FORMATTING STANDARDS:
 - Consistent date format throughout
 - No orphan lines
 - Balanced whitespace
-- ~3-5 lines per bullet point
+- 1-2 lines per bullet point
 - All bullets same indent level within a section
 
 CHECK PROFESSIONAL LANGUAGE:
@@ -140,7 +140,6 @@ Return ALL fields:
 - ats_issues: specific ATS failures found
 """
 
-
 @lru_cache
 def get_combined_reviewer_agent() -> Agent:
     agent = Agent(
@@ -182,6 +181,7 @@ async def combined_review(
     Args:
         optimized: The optimized resume
         job: Job posting to match against
+        source: Original resume source used to supply deterministic header contact info
 
     Returns (result, pdf_bytes, page_count, render_warnings).
     pdf_bytes is None if rendering failed.
@@ -278,13 +278,15 @@ This resume is written in {language.english_name}. This is intentional — the c
 """
 
     agent = get_combined_reviewer_agent()
-    result = await run_with_retry(
-        agent.run,
+    result = await run_tracked_agent(
+        agent,
         [
             prompt,
             BinaryContent(data=image_bytes, media_type="image/png"),
         ],
+        component="LLMChecker",
     )
+
 
     return result.output, pdf_bytes, page_count, render_warnings
 

--- a/src/hr_breaker/agents/extractor.py
+++ b/src/hr_breaker/agents/extractor.py
@@ -1,0 +1,162 @@
+import asyncio
+import logging
+
+from pydantic import BaseModel
+from pydantic_ai import Agent
+
+from hr_breaker.config import (
+    get_flash_model,
+    get_model_settings,
+    get_settings,
+    has_api_key_for_model,
+    required_api_key_env_for_model,
+ )
+from hr_breaker.models.profile import (
+    DocumentExtraction,
+    EducationEntry,
+    ExperienceEntry,
+    PersonalInfo,
+    ProjectEntry,
+    SkillsEntry,
+)
+from hr_breaker.utils.retry import run_with_retry
+
+logger = logging.getLogger(__name__)
+
+
+class _ExperienceResult(BaseModel):
+    experience: list[ExperienceEntry]
+
+
+class _EducationResult(BaseModel):
+    education: list[EducationEntry]
+
+
+class _ProjectsResult(BaseModel):
+    projects: list[ProjectEntry]
+
+
+class _PublicationsResult(BaseModel):
+    publications: list[str]
+
+
+class _SummaryResult(BaseModel):
+    summary: list[str]
+
+
+_SUMMARY_PROMPT = """Extract career summaries from the document.
+Include: professional headlines, "About" / LinkedIn summaries, career objective statements.
+Each distinct paragraph = one list entry. Return [] if none found.
+Do not invent anything not explicitly stated."""
+
+_EXPERIENCE_PROMPT = """Extract work experience entries from the document.
+Each distinct role = one entry: employer, title, start date, end date, bullet points.
+Preserve exact dates, company names, and metrics as written.
+Return [] if none found. Do not invent anything."""
+
+_EDUCATION_PROMPT = """Extract education entries from the document.
+Each degree or program = one entry: institution, degree, field, start/end dates, notes (GPA, honors, coursework).
+Return [] if none found. Do not invent anything."""
+
+_SKILLS_PROMPT = """Extract skills from the document into four categories:
+- technical: programming languages, frameworks, tools, cloud platforms, databases
+- languages: spoken/written human languages (English, Russian, etc.)
+- certifications: named certifications with year if present
+- awards: prizes, honors, recognition
+Return empty lists for absent categories. Do not invent anything."""
+
+_PROJECTS_PROMPT = """Extract side projects, open-source work, and research projects.
+Each project: name, short description, URL only if explicitly written in the document, key bullet points.
+Return [] if none found.
+STRICT: Do NOT construct or infer URLs — only copy URLs that appear verbatim in the document text."""
+
+_PUBLICATIONS_PROMPT = """Extract publications, papers, patents, and articles.
+One free-form string per item: authors, title, venue, year — and include the DOI at the end in parentheses if present in the document, e.g. "(DOI: 10.xxxx/xxxx)".
+Return [] if none found. Do not invent anything."""
+
+_CONTACT_PROMPT = """Extract personal contact information from the document.
+- name: full name of the candidate as written (first + last)
+- email: email address
+- phone: phone number (any format)
+- linkedin: LinkedIn profile URL (full URL or linkedin.com/in/...)
+- github: GitHub profile URL or username (full URL or github.com/...)
+- website: personal website or portfolio URL
+- other_links: ONLY URLs that are explicitly written in the document verbatim — do NOT construct or infer URLs from names or usernames
+
+STRICT RULES:
+- Return null for any field not explicitly present in the document
+- NEVER construct a URL by combining a username with a domain (e.g. do NOT write github.com/user/project unless that exact URL appears in the text)
+- other_links must only contain URLs copied verbatim from the document"""
+
+
+def _strip_hallucinated_urls(info: PersonalInfo, source_text: str) -> PersonalInfo:
+    """Remove any URL fields not verbatim in source_text to prevent hallucinated links."""
+    updates: dict = {}
+    for field in ("linkedin", "github", "website"):
+        url = getattr(info, field)
+        if url and url not in source_text:
+            logger.warning("Stripping hallucinated URL %s=%r (not in source)", field, url)
+            updates[field] = None
+    valid_other = [u for u in info.other_links if u in source_text]
+    if len(valid_other) != len(info.other_links):
+        stripped = set(info.other_links) - set(valid_other)
+        logger.warning("Stripping hallucinated other_links: %s", stripped)
+        updates["other_links"] = valid_other
+    if updates:
+        return info.model_copy(update=updates)
+    return info
+
+def _ensure_extraction_credentials(model_name: str) -> None:
+    required_env = required_api_key_env_for_model(model_name)
+    if required_env and not has_api_key_for_model(model_name):
+        raise RuntimeError(
+            f"Missing API key for extraction model '{model_name}'. Set {required_env} before running profile extraction."
+        )
+
+
+
+async def _run_category(agent: Agent, doc_text: str, label: str):
+    try:
+        result = await run_with_retry(agent.run, doc_text)
+
+        return result.output
+    except Exception as exc:
+        logger.warning("Extraction category '%s' failed: %s", label, exc)
+        return None
+
+
+async def extract_document(content_text: str) -> DocumentExtraction:
+    """Extract structured facts via 6 parallel focused calls. Partial failures use empty defaults."""
+    model_name = get_settings().flash_model
+    _ensure_extraction_credentials(model_name)
+    model = get_flash_model()
+    settings = get_model_settings()
+
+    agents = [
+        Agent(model, output_type=PersonalInfo, system_prompt=_CONTACT_PROMPT, model_settings=settings),
+        Agent(model, output_type=_SummaryResult, system_prompt=_SUMMARY_PROMPT, model_settings=settings),
+        Agent(model, output_type=_ExperienceResult, system_prompt=_EXPERIENCE_PROMPT, model_settings=settings),
+        Agent(model, output_type=_EducationResult, system_prompt=_EDUCATION_PROMPT, model_settings=settings),
+        Agent(model, output_type=SkillsEntry, system_prompt=_SKILLS_PROMPT, model_settings=settings),
+        Agent(model, output_type=_ProjectsResult, system_prompt=_PROJECTS_PROMPT, model_settings=settings),
+        Agent(model, output_type=_PublicationsResult, system_prompt=_PUBLICATIONS_PROMPT, model_settings=settings),
+    ]
+    labels = ["contact", "summary", "experience", "education", "skills", "projects", "publications"]
+
+    results = await asyncio.gather(*[
+        _run_category(agent, content_text, label)
+        for agent, label in zip(agents, labels)
+    ])
+
+    contact_r, summary_r, experience_r, education_r, skills_r, projects_r, publications_r = results
+    personal_info = contact_r if contact_r else PersonalInfo()
+    personal_info = _strip_hallucinated_urls(personal_info, content_text)
+    return DocumentExtraction(
+        personal_info=personal_info,
+        summary=summary_r.summary if summary_r else [],
+        experience=experience_r.experience if experience_r else [],
+        education=education_r.education if education_r else [],
+        skills=skills_r if skills_r else SkillsEntry(),
+        projects=projects_r.projects if projects_r else [],
+        publications=publications_r.publications if publications_r else [],
+    )

--- a/src/hr_breaker/agents/hallucination_detector.py
+++ b/src/hr_breaker/agents/hallucination_detector.py
@@ -6,7 +6,7 @@ from pydantic_ai import Agent
 from hr_breaker.config import get_model_settings, get_pro_model
 from hr_breaker.models import FilterResult, OptimizedResume, ResumeSource
 from hr_breaker.models.language import Language
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 
 class HallucinationResult(BaseModel):
@@ -153,14 +153,15 @@ List any concerns but remember: light assumptions about related technologies are
 
     threshold = 0.6 if no_shame else 0.9
     agent = get_hallucination_agent(no_shame=no_shame)
-    result = await run_with_retry(agent.run, prompt)
+    result = await run_tracked_agent(agent, prompt, component="HallucinationChecker")
+
     r = result.output
 
     issues = []
     suggestions = []
 
     if r.concerns:
-        issues.append(f"Concerns: {', '.join(r.concerns)}")
+        issues.extend(r.concerns)
     if r.no_hallucination_score < threshold:
         suggestions.append(
             f"Score {r.no_hallucination_score:.2f} below {threshold} threshold. {r.reasoning}"

--- a/src/hr_breaker/agents/job_parser.py
+++ b/src/hr_breaker/agents/job_parser.py
@@ -4,7 +4,7 @@ from pydantic_ai import Agent
 
 from hr_breaker.config import get_flash_model, get_model_settings
 from hr_breaker.models import JobPosting
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 SYSTEM_PROMPT = """You are a job posting parser. Extract structured information from job postings.
 
@@ -13,12 +13,11 @@ Extract:
 - company: Company name
 - requirements: List of specific requirements (skills, experience, education)
 - keywords: Technical keywords, tools, technologies mentioned
+- language_code: ISO 639-1 code of the job posting's language (e.g. "en", "ru")
 - description: Brief summary of the role
-- language_code: ISO 639-1 code of the posting's primary language (e.g. "en", "ru", "de", "fr")
 
 Be thorough in extracting keywords - include all technologies, tools, frameworks, methodologies mentioned.
 """
-
 
 @lru_cache
 def get_job_parser_agent() -> Agent:
@@ -33,7 +32,7 @@ def get_job_parser_agent() -> Agent:
 async def parse_job_posting(text: str) -> JobPosting:
     """Parse job posting text into structured data."""
     agent = get_job_parser_agent()
-    result = await run_with_retry(agent.run, f"Parse this job posting:\n\n{text}")
+    result = await run_tracked_agent(agent, f"Parse this job posting:\n\n{text}", component="JobParser")
     job = result.output
     job.raw_text = text
     return job

--- a/src/hr_breaker/agents/optimizer.py
+++ b/src/hr_breaker/agents/optimizer.py
@@ -19,7 +19,7 @@ from hr_breaker.models.language import Language
 from hr_breaker.services.length_estimator import estimate_content_length
 from hr_breaker.services.renderer import HTMLRenderer, RenderError
 from hr_breaker.utils import extract_text_from_html
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,9 @@ CONTENT RULES:
 - Add a summary section highlighting the most relevant experiences.
 - Try to preserve the original writing style if possible.
 - Avoid leaving an empty space at the bottom of the page if you have useful content to fill.
+- PROJECTS: Only include projects directly relevant to this job. Skip projects already listed under Publications. If no projects are relevant, omit the section entirely.
+- PUBLICATIONS: Always use "PUBLICATIONS" (plural) as the section title, even for a single item.
+- EDUCATION: By default include only the most recent / highest degree. Include multiple degrees only if they are both relevant to the role.
 
 {content_rules}
 
@@ -72,7 +75,21 @@ OPTIONAL TOOLS (use when helpful):
 LINKS:
 - Preserve contacts info as in the original and never delete it
 - Preserve URLs from the original resume (email, LinkedIn, GitHub, website, project links)
-- Use full URLs (include https://) for all links
+- Use full URLs (include https://) in the href attribute of every <a> tag
+- Link display text must NOT start with https:// or http:// — show just the domain+path (e.g. linkedin.com/in/username, github.com/username)
+
+PUBLICATIONS:
+- Always append the DOI in parentheses at the end if available, e.g. "Author et al., Title, Venue Year (DOI: 10.xxxx/xxxx)"
+
+PROFILE SOURCE (when input contains "## Contact" or "## Source documents ranked by relevance"):
+- The input is a MERGED PROFILE from multiple documents — it contains more content than one resume
+- "Candidate name:" field → use as the resume H1 name (first + last name)
+- "## Contact" → copy these fields ONLY into the header contact line (email, phone, LinkedIn, GitHub, website)
+- "## Additional links" → these are reference links for inline use in projects/publications, NOT for the header
+- "## Source documents ranked by relevance" → use to decide which experiences to highlight and trim
+- Be selective: include only the 3-5 most relevant experience entries for this specific job
+- Summary: 2-3 sentences maximum, tightly focused on this specific role
+- You MUST trim aggressively to fit one page — call check_content_length early and cut ruthlessly
 
 {resume_guide}
 """
@@ -84,10 +101,10 @@ ALLOWED:
 - Rephrasing metrics with same values: "1% - 10%" -> "1-10%"
 - Reordering and emphasizing existing content
 - Using content that is commented out and making it visible
-- You CAN use <style> tags if you need custom styling beyond the provided classes 
+- You CAN use <style> tags if you need custom styling beyond the provided classes
 
 STRICT RULES - NEVER VIOLATE:
-- Only add specific technologies, products, or platforms not in original (e.g. "Amazon Bedrock", "LangChain", "Pinecone") they can be justified (user has experience with PostgreSQL -> maybe they are familiar with MySQL too) and ONLY IF there is no other way to increase fit 
+- NEVER add specific named products or platforms absent from the original (e.g. "Amazon Bedrock", "LangChain", "Pinecone") unless they are a direct, obvious companion to something explicitly present (e.g. PostgreSQL user → may know MySQL) AND there is no other way to improve fit
 - NEVER fabricate job titles, companies, degrees, certifications, or achievements
 - NEVER invent metrics, numbers and achievements not in original
 - DO NOT drop work experience or achievements (publications, patents, awards, etc.) unless they decrease fit
@@ -105,7 +122,7 @@ ALLOWED:
 - Rephrasing metrics with same values: "1% - 10%" -> "1-10%"
 - Reordering and emphasizing existing content
 - Using content that is commented out and making it visible
-- You CAN use <style> tags if you need custom styling beyond the provided classes 
+- You CAN use <style> tags if you need custom styling beyond the provided classes
 
 STRICT RULES - NEVER VIOLATE:
 - NEVER fabricate job titles, companies, degrees, certifications, or achievements
@@ -271,12 +288,6 @@ Generate the resume HTML in {language.english_name} language.
 - Use accepted {language.english_name} equivalents where they exist and are commonly used
 - Text often expands in {language.english_name} vs English — compensate with concise phrasing, shorter synonyms, or abbreviations accepted in {language.english_name} professional context. Do NOT drop content — condense wording instead.
 """
-    else:
-        prompt += """
-## TARGET LANGUAGE: English
-
-Generate the resume HTML in English. Even if the job posting is in another language, the resume MUST be in English.
-"""
 
     if context.last_attempt:
         estimate = estimate_content_length(context.last_attempt)
@@ -313,7 +324,7 @@ Output ONLY valid JSON. The html field should contain the raw HTML string.
 """
 
     agent = get_optimizer_agent(job, source, no_shame=no_shame)
-    result = await run_with_retry(agent.run, prompt)
+    result = await run_tracked_agent(agent, prompt, component="Optimizer")
     return OptimizedResume(
         html=result.output.html,
         iteration=context.iteration,

--- a/src/hr_breaker/agents/translation_checker.py
+++ b/src/hr_breaker/agents/translation_checker.py
@@ -9,7 +9,7 @@ from pydantic_ai import Agent
 from hr_breaker.config import get_flash_model, get_model_settings
 from hr_breaker.models import FilterResult, JobPosting, OptimizedResume, ResumeSource
 from hr_breaker.models.language import Language
-from hr_breaker.utils.retry import run_with_retry
+from hr_breaker.utils.optimization_telemetry import run_tracked_agent
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ Rate the {language.english_name} language quality. Be specific about issues — 
 """
 
     agent = get_translation_checker_agent(language)
-    result = await run_with_retry(agent.run, prompt)
+    result = await run_tracked_agent(agent, prompt, component="TranslationQualityChecker")
     r = result.output
 
     logger.debug(

--- a/src/hr_breaker/cli.py
+++ b/src/hr_breaker/cli.py
@@ -12,11 +12,13 @@ from hr_breaker.agents import extract_name, parse_job_posting
 from hr_breaker.config import get_settings
 from hr_breaker.models import (
     GeneratedPDF,
+    JobPosting,
     ResumeSource,
     SUPPORTED_LANGUAGES,
     get_language_safe,
     resolve_target_language,
 )
+from hr_breaker.models.profile import document_needs_extraction, get_document_extraction
 from hr_breaker.orchestration import optimize_for_job
 from hr_breaker.services import (
     PDFStorage,
@@ -28,6 +30,37 @@ from hr_breaker.services.pdf_storage import generate_run_id
 from hr_breaker.services.pdf_parser import load_resume_content
 
 
+# ---------------------------------------------------------------------------
+# Helpers for extraction state display
+# ---------------------------------------------------------------------------
+
+def _format_extraction_state(doc) -> str:
+    status = str(doc.metadata.get("extraction_status") or "").lower()
+    if status == "empty":
+        return "empty extraction"
+    if status == "failed":
+        return "failed extraction"
+    if get_document_extraction(doc) is not None:
+        return "extracted"
+    return "no extraction"
+
+
+def _print_extraction_result(doc) -> str:
+    status = str(doc.metadata.get("extraction_status") or "").lower()
+    if status == "done":
+        click.echo(" ok")
+        return "done"
+    if status == "empty":
+        click.echo(" empty")
+        return "empty"
+    click.echo(f" unexpected status: {status or 'missing'}")
+    return "unexpected"
+
+
+# ---------------------------------------------------------------------------
+# CLI group
+# ---------------------------------------------------------------------------
+
 @click.group()
 def cli():
     """HR-Breaker: Optimize resumes for job postings."""
@@ -37,9 +70,143 @@ def cli():
 OUTPUT_DIR = Path("output")
 
 
+# ---------------------------------------------------------------------------
+# profile subcommand group
+# ---------------------------------------------------------------------------
+
+@cli.group()
+def profile():
+    """Manage profile archives."""
+    pass
+
+
+@profile.command("list")
+def profile_list():
+    """List all profiles."""
+    from hr_breaker.services.profile_store import ProfileStore
+
+    store = ProfileStore()
+    profiles = store.list_profiles()
+    if not profiles:
+        click.echo("No profiles found. Create one with: hr-breaker profile create <name>")
+        return
+    for p in profiles:
+        name_part = f" ({p.full_name})" if p.full_name else ""
+        doc_count = len(store.list_documents(p.id))
+        click.echo(f"  {p.id:30s}  {p.display_name}{name_part}  [{doc_count} doc(s)]")
+
+
+@profile.command("create")
+@click.argument("name")
+@click.option("--first-name", default=None, help="Candidate first name")
+@click.option("--last-name", default=None, help="Candidate last name")
+@click.option("--instructions", "-i", default=None, help="Standing instructions for the optimizer")
+def profile_create(name: str, first_name: str | None, last_name: str | None, instructions: str | None):
+    """Create a new profile archive.
+
+    NAME: Display name for the profile (e.g. "John Doe")
+    """
+    from hr_breaker.services.profile_store import ProfileStore
+
+    store = ProfileStore()
+    p = store.create_profile(name, first_name=first_name, last_name=last_name, instructions=instructions)
+    click.echo(f"Created profile: {p.id}  ({p.display_name})")
+
+
+@profile.command("show")
+@click.argument("profile_id")
+def profile_show(profile_id: str):
+    """Show profile details and its documents."""
+    from hr_breaker.services.profile_store import ProfileStore
+
+    store = ProfileStore()
+    p = store.get_profile(profile_id)
+    if p is None:
+        raise click.ClickException(f"Profile not found: {profile_id}")
+
+    click.echo(f"ID:           {p.id}")
+    click.echo(f"Name:         {p.display_name}")
+    if p.full_name:
+        click.echo(f"Full name:    {p.full_name}")
+    if p.instructions:
+        click.echo(f"Instructions: {p.instructions}")
+    click.echo(f"Updated:      {p.updated_at.strftime('%Y-%m-%d %H:%M')}")
+
+    docs = store.list_documents(p.id)
+    click.echo(f"\nDocuments ({len(docs)}):")
+    if not docs:
+        click.echo("  (none — add with: hr-breaker profile add <profile-id> <file>)")
+    for doc in docs:
+        extraction_state = _format_extraction_state(doc)
+        incl = "+" if doc.included_by_default else "-"
+        click.echo(f"  [{incl}] {doc.id[:12]}  {doc.title:40s}  [{doc.kind}, {extraction_state}]")
+
+
+@profile.command("add")
+@click.argument("profile_id")
+@click.argument("files", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path))
+@click.option("--extract", is_flag=True, help="Run fact extraction immediately after adding")
+@click.option("--exclude", is_flag=True, help="Add as excluded by default")
+def profile_add(profile_id: str, files: tuple[Path, ...], extract: bool, exclude: bool):
+    """Add one or more files to a profile.
+
+    PROFILE_ID: Target profile ID (see: hr-breaker profile list)
+    FILES:      One or more file paths to add
+    """
+    from hr_breaker.services.profile_store import ProfileStore
+
+    store = ProfileStore()
+    p = store.get_profile(profile_id)
+    if p is None:
+        raise click.ClickException(f"Profile not found: {profile_id}")
+
+    added_ids: list[str] = []
+    for file_path in files:
+        click.echo(f"  Adding {file_path.name}...", nl=False)
+        try:
+            doc = store.add_upload(
+                profile_id,
+                filename=file_path.name,
+                data=file_path.read_bytes(),
+                included_by_default=not exclude,
+            )
+            added_ids.append(doc.id)
+            click.echo(f" ok ({doc.id[:12]})")
+        except Exception as exc:
+            click.echo(f" failed: {exc}")
+
+    if extract and added_ids:
+        click.echo("Extracting facts...")
+
+        async def run_extract():
+            for doc_id in added_ids:
+                click.echo(f"  {doc_id[:12]}...", nl=False)
+                try:
+                    updated = await store.extract_document_content(profile_id, doc_id)
+                    if updated is None:
+                        click.echo(" missing")
+                        continue
+                    _print_extraction_result(updated)
+                except Exception as exc:
+                    click.echo(f" failed: {exc}")
+
+        asyncio.run(run_extract())
+    elif added_ids and not extract:
+        click.echo(f"Tip: run 'hr-breaker backfill --profile {profile_id}' to extract facts.")
+
+
+# ---------------------------------------------------------------------------
+# optimize command
+# ---------------------------------------------------------------------------
+
 @cli.command()
-@click.argument("resume_path", type=click.Path(exists=True, path_type=Path))
-@click.argument("job_input")
+@click.argument("resume_path", required=False, type=click.Path(path_type=Path), default=None)
+@click.argument("job_input", required=False, default=None)
+@click.option(
+    "--profile", "-p", "profile_id",
+    default=None,
+    help="Use a profile archive instead of a resume file.",
+)
 @click.option(
     "--output",
     "-o",
@@ -78,7 +245,7 @@ OUTPUT_DIR = Path("output")
         case_sensitive=False,
     ),
     default=None,
-    help="Language mode: from_job (detect from job), from_resume (detect from resume), or ISO code (default: from_job).",
+    help="Language mode: from_job (detect from job), from_resume (detect from resume), or ISO code.",
 )
 @click.option(
     "--instructions",
@@ -87,9 +254,15 @@ OUTPUT_DIR = Path("output")
     default=None,
     help="Instructions for the optimizer (extra experience, emphasis areas)",
 )
+@click.option(
+    "--docs",
+    default=None,
+    help="Comma-separated document IDs to include (profile mode only; default: all included_by_default)",
+)
 def optimize(
-    resume_path: Path,
-    job_input: str,
+    resume_path: Path | None,
+    job_input: str | None,
+    profile_id: str | None,
     output: Path | None,
     max_iterations: int | None,
     debug: bool,
@@ -97,16 +270,42 @@ def optimize(
     no_shame: bool,
     lang: str | None,
     instructions: str | None,
+    docs: str | None,
 ):
-    """Optimize resume for job posting.
+    """Optimize a resume for a job posting.
 
-    RESUME_PATH: Path to resume file (.tex, .md, .txt, .pdf, etc.)
-    JOB_INPUT: URL or path to file with job description
+    Direct upload mode:
+
+        hr-breaker optimize resume.txt https://example.com/job
+
+    Profile archive mode:
+
+        hr-breaker optimize --profile <id> https://example.com/job
+
+    JOB_INPUT: URL or path to a file containing the job description.
     """
-    resume_content = load_resume_content(resume_path)
+    if profile_id is None and resume_path is None:
+        raise click.UsageError(
+            "Provide either RESUME_PATH or --profile <id>.\n"
+            "  Direct:  hr-breaker optimize resume.txt <job>\n"
+            "  Profile: hr-breaker optimize --profile <id> <job>"
+        )
+    if profile_id is not None and resume_path is not None:
+        raise click.UsageError("Cannot use both RESUME_PATH and --profile at the same time.")
 
-    # Get job text (sync - may need user interaction for Cloudflare)
-    job_text = _get_job_text(job_input)
+    # Handle: hr-breaker optimize --profile id <job>  (job ends up in resume_path slot)
+    effective_job_input = job_input
+    if profile_id is not None and job_input is None and resume_path is not None:
+        effective_job_input = str(resume_path)
+        resume_path = None
+
+    if effective_job_input is None:
+        raise click.UsageError("JOB_INPUT is required (URL or path to job description).")
+
+    if resume_path is not None and not resume_path.exists():
+        raise click.ClickException(f"Resume file not found: {resume_path}")
+
+    job_text = _get_job_text(effective_job_input)
 
     pdf_storage = PDFStorage()
     run_id = generate_run_id()
@@ -121,38 +320,48 @@ def optimize(
         )
         click.echo(f"  Iteration {i + 1}: {status} [{scores}]")
 
-        # Save intermediate PDF in debug mode
         if debug and debug_dir:
-            debug_pdf = debug_dir / f"iteration_{i + 1}.pdf"
-            # Save HTML or JSON depending on what's available
             if optimized.html:
                 debug_html = debug_dir / f"iteration_{i + 1}.html"
                 debug_html.write_text(optimized.html, encoding="utf-8")
             elif optimized.data:
                 debug_json = debug_dir / f"iteration_{i + 1}.json"
-                debug_json.write_text(
-                    optimized.data.model_dump_json(indent=2), encoding="utf-8"
-                )
+                debug_json.write_text(optimized.data.model_dump_json(indent=2), encoding="utf-8")
             if optimized.pdf_bytes:
+                debug_pdf = debug_dir / f"iteration_{i + 1}.pdf"
                 debug_pdf.write_bytes(optimized.pdf_bytes)
                 click.echo(f"    Debug: saved {debug_pdf}")
             else:
-                click.echo(f"    Debug: no PDF (render failed)")
+                click.echo("    Debug: no PDF (render failed)")
 
     settings = get_settings()
     lang_mode = lang or settings.default_language
 
-    # Run all async work in single event loop
     async def run_optimization():
         nonlocal debug_dir
-        first_name, last_name, resume_lang_code = await extract_name(resume_content)
-        click.echo(f"Resume: {first_name or 'Unknown'} {last_name or ''} (lang: {resume_lang_code})")
 
-        # Parse job first to get company/role for debug dir
-        job = await parse_job_posting(job_text)
+        pre_parsed_job = None
+        if profile_id is not None:
+            source, pre_parsed_job = await _build_profile_source(profile_id, job_text, docs_filter=docs)
+            first_name = source.first_name
+            last_name = source.last_name
+            resume_lang_code = source.language_code or "en"
+            name_str = f"{first_name or ''} {last_name or ''}".strip()
+            click.echo(f"Profile: {profile_id}" + (f"  ({name_str})" if name_str else ""))
+        else:
+            resume_content = load_resume_content(resume_path)
+            first_name, last_name, resume_lang_code = await extract_name(resume_content)
+            click.echo(f"Resume: {first_name or 'Unknown'} {last_name or ''} (lang: {resume_lang_code})")
+            source = ResumeSource(
+                content=resume_content,
+                first_name=first_name,
+                last_name=last_name,
+                language_code=resume_lang_code,
+            )
+
+        job = pre_parsed_job or await parse_job_posting(job_text)
         click.echo(f"Job: {job.title} at {job.company} (lang: {job.language_code})")
 
-        # Resolve language mode
         target_language = resolve_target_language(lang_mode, job.language_code, resume_lang_code)
         source_lang = get_language_safe(resume_lang_code)
 
@@ -163,12 +372,6 @@ def optimize(
         shame_mode = " [no-shame]" if no_shame else ""
         click.echo(f"Optimizing (mode: {mode}{shame_mode}, target: {target_language.english_name})...")
 
-        source = ResumeSource(
-            content=resume_content,
-            first_name=first_name,
-            last_name=last_name,
-            language_code=resume_lang_code,
-        )
         optimized, validation, _ = await optimize_for_job(
             source,
             max_iterations=max_iterations,
@@ -190,7 +393,6 @@ def optimize(
     if not validation.passed:
         click.echo("Warning: Not all filters passed")
 
-    # Save final PDF (reuse bytes from last iteration)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     if output is None:
         output = (
@@ -218,9 +420,111 @@ def optimize(
         last_name=last_name,
     )
     pdf_storage.save_record(pdf_record)
-
     click.echo(f"PDF saved: {output}")
 
+
+async def _build_profile_source(
+    profile_id: str,
+    job_text: str,
+    *,
+    docs_filter: str | None,
+) -> "tuple[ResumeSource, JobPosting]":
+    """Rank profile documents against the job and return (ResumeSource, JobPosting)."""
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.profile_retrieval import rank_profile_documents, synthesize_profile_resume_source
+
+    store = ProfileStore()
+    p = store.get_profile(profile_id)
+    if p is None:
+        raise click.ClickException(f"Profile not found: {profile_id}")
+
+    all_docs = store.list_documents(profile_id)
+    if not all_docs:
+        raise click.ClickException(
+            f"Profile '{profile_id}' has no documents. "
+            f"Add some with: hr-breaker profile add {profile_id} <file>"
+        )
+
+    if docs_filter:
+        wanted = {d.strip() for d in docs_filter.split(",")}
+        selected = [d for d in all_docs if d.id in wanted or d.id[:12] in wanted]
+        if not selected:
+            raise click.ClickException(f"No documents matched --docs filter: {docs_filter}")
+    else:
+        selected = [d for d in all_docs if d.included_by_default] or all_docs
+
+    missing_extraction = [d.title for d in selected if document_needs_extraction(d)]
+    if missing_extraction:
+        click.echo(
+            f"Warning: {len(missing_extraction)} document(s) have no extracted facts "
+            f"and will be used as raw text: {', '.join(missing_extraction)}\n"
+            f"  Run 'hr-breaker backfill --profile {profile_id}' to fix this."
+        )
+
+    job = await parse_job_posting(job_text)
+    ranked = await rank_profile_documents(selected, job)
+    return synthesize_profile_resume_source(p, selected, ranked), job
+
+
+# ---------------------------------------------------------------------------
+# backfill command
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.option("--profile", "-p", "profile_id", default=None, help="Profile ID to backfill (default: all)")
+@click.option("--force", is_flag=True, help="Re-extract even if extraction already exists")
+def backfill(profile_id: str | None, force: bool):
+    """Extract facts from profile documents that are missing extraction data."""
+    from hr_breaker.services.profile_store import ProfileStore
+
+    store = ProfileStore()
+    if profile_id:
+        p = store.get_profile(profile_id)
+        if p is None:
+            raise click.ClickException(f"Profile not found: {profile_id}")
+        profiles = [p]
+    else:
+        profiles = store.list_profiles()
+
+    if not profiles:
+        click.echo("No profiles found.")
+        return
+
+    total = done = empty = failed = 0
+
+    async def run():
+        nonlocal total, done, empty, failed
+        for p in profiles:
+            docs = store.list_documents(p.id)
+            pending = [d for d in docs if force or document_needs_extraction(d)]
+            click.echo(f"Profile '{p.display_name}': {len(pending)}/{len(docs)} document(s) to process")
+            for doc in pending:
+                total += 1
+                click.echo(f"  {doc.title}...", nl=False)
+                try:
+                    updated = await store.extract_document_content(p.id, doc.id)
+                    if updated is None:
+                        failed += 1
+                        click.echo(" failed: document disappeared")
+                        continue
+                    result = _print_extraction_result(updated)
+                    if result == "done":
+                        done += 1
+                    elif result == "empty":
+                        empty += 1
+                    else:
+                        failed += 1
+                except Exception as exc:
+                    failed += 1
+                    click.echo(f" failed: {exc}")
+
+    asyncio.run(run())
+    click.echo(f"\nDone: {done} extracted, {empty} empty, {failed} failed, {total} total")
+
+
+# ---------------------------------------------------------------------------
+# list command
+# ---------------------------------------------------------------------------
 
 @cli.command("list")
 def list_history():
@@ -240,19 +544,39 @@ def list_history():
         )
 
 
+# ---------------------------------------------------------------------------
+# serve command
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.option("--port", "-p", type=int, default=8899, help="Port to serve on")
+@click.option("--open/--no-open", default=True, help="Auto-open browser")
+def serve(port: int, open: bool):
+    """Start the web UI server."""
+    url = f"http://localhost:{port}"
+    click.echo(f"Starting HR-Breaker at {url}")
+
+    if open:
+        threading.Timer(1.5, webbrowser.open, args=[url]).start()
+
+    uvicorn.run("hr_breaker.server:app", host="0.0.0.0", port=port, log_level="warning")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
 def _get_job_text(job_input: str) -> str:
     """Get job text from URL or file path."""
-    # Check if file
     path = Path(job_input)
     if path.exists():
         return path.read_text(encoding="utf-8")
 
-    # Check if URL
     if job_input.startswith(("http://", "https://")):
         try:
             return scrape_job_posting(job_input)
         except CloudflareBlockedError:
-            click.echo(f"Site has bot protection. Opening in browser...")
+            click.echo("Site has bot protection. Opening in browser...")
             click.launch(job_input)
             click.echo("Please copy the job description and paste below.")
             click.echo("(Press Enter twice when done)")
@@ -260,7 +584,6 @@ def _get_job_text(job_input: str) -> str:
         except ScrapingError as e:
             raise click.ClickException(str(e))
 
-    # Treat as raw text
     return job_input
 
 
@@ -285,20 +608,6 @@ def _read_multiline_input() -> str:
     if not text:
         raise click.ClickException("No job description provided")
     return text
-
-
-@cli.command()
-@click.option("--port", "-p", type=int, default=8899, help="Port to serve on")
-@click.option("--open/--no-open", default=True, help="Auto-open browser")
-def serve(port: int, open: bool):
-    """Start the web UI server."""
-    url = f"http://localhost:{port}"
-    click.echo(f"Starting HR-Breaker at {url}")
-
-    if open:
-        threading.Timer(1.5, webbrowser.open, args=[url]).start()
-
-    uvicorn.run("hr_breaker.server:app", host="0.0.0.0", port=port, log_level="warning")
 
 
 if __name__ == "__main__":

--- a/src/hr_breaker/config.py
+++ b/src/hr_breaker/config.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import os
+import threading
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -36,6 +37,9 @@ def setup_logging() -> logging.Logger:
 
 
 logger = setup_logging()
+
+
+_SETTINGS_OVERRIDE_LOCK = threading.RLock()
 
 
 class Settings(BaseSettings):
@@ -237,47 +241,52 @@ _API_KEY_ENV_MAP = {
 
 @contextlib.contextmanager
 def settings_override(overrides: dict | None):
-    """Temporarily override settings via env vars, restoring originals on exit."""
+    """Temporarily override settings via env vars, restoring originals on exit.
+
+    Overrides are serialized because the app still relies on process-global env vars
+    for downstream model/provider clients. This avoids cross-request leakage.
+    """
     if not overrides:
         yield
         return
 
-    saved: dict[str, str | None] = {}
+    with _SETTINGS_OVERRIDE_LOCK:
+        saved: dict[str, str | None] = {}
 
-    # Apply field overrides
-    for field, value in overrides.items():
-        if field == "api_keys":
-            continue
-        if value is None:
-            continue
-        env_var = _FIELD_ENV_MAP.get(field)
-        if env_var is None:
-            continue
-        saved[env_var] = os.environ.get(env_var)
-        os.environ[env_var] = str(value)
-
-    # Apply API key overrides
-    api_keys = overrides.get("api_keys")
-    if api_keys:
-        for provider, key_value in api_keys.items():
-            if key_value is None:
+        # Apply field overrides
+        for field, value in overrides.items():
+            if field == "api_keys":
                 continue
-            env_var = _API_KEY_ENV_MAP.get(provider)
+            if value is None:
+                continue
+            env_var = _FIELD_ENV_MAP.get(field)
             if env_var is None:
                 continue
             saved[env_var] = os.environ.get(env_var)
-            os.environ[env_var] = str(key_value)
+            os.environ[env_var] = str(value)
 
-    get_settings.cache_clear()
-    try:
-        yield
-    finally:
-        for env_var, original in saved.items():
-            if original is None:
-                os.environ.pop(env_var, None)
-            else:
-                os.environ[env_var] = original
+        # Apply API key overrides
+        api_keys = overrides.get("api_keys")
+        if api_keys:
+            for provider, key_value in api_keys.items():
+                if key_value is None:
+                    continue
+                env_var = _API_KEY_ENV_MAP.get(provider)
+                if env_var is None:
+                    continue
+                saved[env_var] = os.environ.get(env_var)
+                os.environ[env_var] = str(key_value)
+
         get_settings.cache_clear()
+        try:
+            yield
+        finally:
+            for env_var, original in saved.items():
+                if original is None:
+                    os.environ.pop(env_var, None)
+                else:
+                    os.environ[env_var] = original
+            get_settings.cache_clear()
 
 
 def get_model_settings() -> dict[str, Any] | None:

--- a/src/hr_breaker/config.py
+++ b/src/hr_breaker/config.py
@@ -26,7 +26,7 @@ def setup_logging() -> logging.Logger:
 
     logging.basicConfig(
         level=getattr(logging, general_level, logging.WARNING),
-        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        format="%(asctime)s.%(msecs)03d [%(levelname)s] %(name)s - %(message)s",
         datefmt="%H:%M:%S",
     )
 
@@ -50,11 +50,28 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("MOONSHOT_API_KEY"),
     )
+    openai_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENAI_API_BASE", "OPENAI_BASE_URL"),
+    )
+    pro_openai_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("PRO_OPENAI_API_BASE"),
+    )
+    flash_openai_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("FLASH_OPENAI_API_BASE"),
+    )
+    embedding_openai_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("EMBEDDING_OPENAI_API_BASE"),
+    )
 
     pro_model: str = "gemini/gemini-3-pro-preview"
     flash_model: str = "gemini/gemini-3-flash-preview"
     reasoning_effort: str = "medium"
     cache_dir: Path = Path(".cache/resumes")
+    profile_dir: Path = Path(".cache/profiles")
     output_dir: Path = Path("output")
     max_iterations: int = 5
     pass_threshold: float = 0.7
@@ -93,6 +110,11 @@ class Settings(BaseSettings):
     embedding_model: str = "openrouter/google/gemini-embedding-001"
     embedding_output_dimensionality: int = 768
 
+    # Profile archive settings
+    profile_retrieval_top_k: int = 4
+    profile_source_max_chars: int = 12000
+    profile_snippet_max_chars: int = 700
+
     # Agent limits
     agent_name_extractor_chars: int = 2000
 
@@ -108,6 +130,14 @@ class Settings(BaseSettings):
             os.environ["GEMINI_API_KEY"] = self.gemini_api_key
         if self.moonshot_api_key and "MOONSHOT_API_KEY" not in os.environ:
             os.environ["MOONSHOT_API_KEY"] = self.moonshot_api_key
+        if self.openai_api_base and "OPENAI_API_BASE" not in os.environ:
+            os.environ["OPENAI_API_BASE"] = self.openai_api_base
+        if self.pro_openai_api_base and "PRO_OPENAI_API_BASE" not in os.environ:
+            os.environ["PRO_OPENAI_API_BASE"] = self.pro_openai_api_base
+        if self.flash_openai_api_base and "FLASH_OPENAI_API_BASE" not in os.environ:
+            os.environ["FLASH_OPENAI_API_BASE"] = self.flash_openai_api_base
+        if self.embedding_openai_api_base and "EMBEDDING_OPENAI_API_BASE" not in os.environ:
+            os.environ["EMBEDDING_OPENAI_API_BASE"] = self.embedding_openai_api_base
 
 
 @lru_cache
@@ -115,12 +145,68 @@ def get_settings() -> Settings:
     return Settings()
 
 
+def clear_settings_cache() -> None:
+    """Clear cached settings (for tests)."""
+    get_settings.cache_clear()
+
+
+def required_api_key_env_for_model(model_name: str) -> str | None:
+    if model_name.startswith("openrouter/"):
+        return "OPENROUTER_API_KEY"
+    if model_name.startswith("gemini/") or "gemini" in model_name:
+        return "GEMINI_API_KEY"
+    if model_name.startswith("openai/"):
+        return "OPENAI_API_KEY"
+    if model_name.startswith("anthropic/"):
+        return "ANTHROPIC_API_KEY"
+    if model_name.startswith("moonshot/"):
+        return "MOONSHOT_API_KEY"
+    return None
+
+
+def has_api_key_for_model(model_name: str) -> bool:
+    env_var = required_api_key_env_for_model(model_name)
+    if env_var == "GEMINI_API_KEY":
+        return bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+    if env_var is not None:
+        return bool(os.environ.get(env_var))
+    return bool(
+        os.environ.get("GEMINI_API_KEY")
+        or os.environ.get("GOOGLE_API_KEY")
+        or os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("MOONSHOT_API_KEY")
+    )
+
+
+def _litellm_api_base_for_model(scope: str, model_name: str) -> str | None:
+    settings = get_settings()
+    if not model_name.startswith("openai/"):
+        return None
+    scoped_field = {
+        "pro": "pro_openai_api_base",
+        "flash": "flash_openai_api_base",
+        "embedding": "embedding_openai_api_base",
+    }[scope]
+    return getattr(settings, scoped_field) or settings.openai_api_base
+
+
+def _litellm_model(scope: str, model_name: str) -> LiteLLMModel:
+    return LiteLLMModel(model_name=model_name, api_base=_litellm_api_base_for_model(scope, model_name))
+
+
 def get_pro_model() -> LiteLLMModel:
-    return LiteLLMModel(model_name=get_settings().pro_model)
+    return _litellm_model("pro", get_settings().pro_model)
 
 
 def get_flash_model() -> LiteLLMModel:
-    return LiteLLMModel(model_name=get_settings().flash_model)
+    return _litellm_model("flash", get_settings().flash_model)
+
+
+def get_embedding_api_base() -> str | None:
+    settings = get_settings()
+    return _litellm_api_base_for_model("embedding", settings.embedding_model)
 
 
 _FIELD_ENV_MAP = {
@@ -128,6 +214,10 @@ _FIELD_ENV_MAP = {
     "flash_model": "FLASH_MODEL",
     "embedding_model": "EMBEDDING_MODEL",
     "reasoning_effort": "REASONING_EFFORT",
+    "openai_api_base": "OPENAI_API_BASE",
+    "pro_openai_api_base": "PRO_OPENAI_API_BASE",
+    "flash_openai_api_base": "FLASH_OPENAI_API_BASE",
+    "embedding_openai_api_base": "EMBEDDING_OPENAI_API_BASE",
     "filter_hallucination_threshold": "FILTER_HALLUCINATION_THRESHOLD",
     "filter_keyword_threshold": "FILTER_KEYWORD_THRESHOLD",
     "filter_llm_threshold": "FILTER_LLM_THRESHOLD",

--- a/src/hr_breaker/filters/translation_checker.py
+++ b/src/hr_breaker/filters/translation_checker.py
@@ -8,7 +8,7 @@ from hr_breaker.models.language import Language
 
 @FilterRegistry.register
 class TranslationQualityChecker(BaseFilter):
-    """Evaluate translation quality for non-English resumes. Skipped for English."""
+    """Evaluate translation quality for non-English resumes. Skipped when no translation needed."""
 
     name = "TranslationQualityChecker"
     priority = 8  # Run last — no point checking translation if content fails

--- a/src/hr_breaker/filters/vector_similarity_matcher.py
+++ b/src/hr_breaker/filters/vector_similarity_matcher.py
@@ -1,10 +1,11 @@
 from litellm import aembedding as litellm_aembedding
 
-from hr_breaker.config import get_settings
+from hr_breaker.config import get_embedding_api_base, get_settings
 from hr_breaker.filters.base import BaseFilter
 from hr_breaker.filters.registry import FilterRegistry
 from hr_breaker.models import FilterResult, JobPosting, OptimizedResume, ResumeSource
 from hr_breaker.models.language import Language
+from hr_breaker.utils.optimization_telemetry import report_usage
 from hr_breaker.utils.retry import run_with_retry
 
 
@@ -43,12 +44,23 @@ class VectorSimilarityMatcher(BaseFilter):
         job_text = f"{job.title} {job.description} {' '.join(job.requirements)}"
 
         try:
-            result = await run_with_retry(
-                litellm_aembedding,
-                model=settings.embedding_model,
-                input=[resume_text, job_text],
-                dimensions=settings.embedding_output_dimensionality,
-            )
+            api_base = get_embedding_api_base()
+            if api_base:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    input=[resume_text, job_text],
+                    dimensions=settings.embedding_output_dimensionality,
+                    api_base=api_base,
+                )
+            else:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    input=[resume_text, job_text],
+                    dimensions=settings.embedding_output_dimensionality,
+                )
+            report_usage("VectorSimilarityMatcher", settings.embedding_model, getattr(result, "usage", None))
             embeddings = [item["embedding"] for item in result.data]
         except Exception as e:
             return FilterResult(

--- a/src/hr_breaker/litellm_patch.py
+++ b/src/hr_breaker/litellm_patch.py
@@ -6,8 +6,12 @@ OpenAI-compatible image_url parts that litellm forwards to any provider.
 """
 
 import base64
+import inspect
+from collections.abc import Coroutine
 from typing import Any
 
+import litellm
+from litellm.litellm_core_utils.logging_worker import LoggingWorker
 from pydantic_ai.messages import (
     BinaryContent,
     ImageUrl,
@@ -20,11 +24,12 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
-)
+    )
 from pydantic_ai._utils import guard_tool_call_id as _guard_tool_call_id
 from pydantic_ai_litellm import LiteLLMModel
 
-_ORIGINAL = LiteLLMModel._map_messages
+_ORIGINAL_MAP_MESSAGES = LiteLLMModel._map_messages
+_ORIGINAL_ENSURE_INITIALIZED_AND_ENQUEUE = LoggingWorker.ensure_initialized_and_enqueue
 
 
 def _convert_user_content(content) -> str | list[dict[str, Any]]:
@@ -50,9 +55,36 @@ def _convert_user_content(content) -> str | list[dict[str, Any]]:
     return parts
 
 
+def _has_async_litellm_callbacks(async_coroutine: Coroutine[Any, Any, Any] | None = None) -> bool:
+    if litellm._async_success_callback or litellm._async_failure_callback:
+        return True
+    if async_coroutine is None:
+        return False
+    owner = inspect.getcoroutinelocals(async_coroutine).get("self")
+    if owner is None:
+        return False
+    return bool(
+        getattr(owner, "dynamic_async_success_callbacks", None)
+        or getattr(owner, "dynamic_async_failure_callbacks", None)
+    )
+
+
+def _patched_ensure_initialized_and_enqueue(
+    self: LoggingWorker, async_coroutine: Coroutine[Any, Any, Any]
+    ) -> None:
+    # LiteLLM starts the background LoggingWorker even when there are no async
+    # callbacks configured. In this app that worker has no useful work and can
+    # survive until loop teardown, producing pending-task warnings on exit.
+    if not _has_async_litellm_callbacks(async_coroutine):
+        async_coroutine.close()
+        return
+
+    _ORIGINAL_ENSURE_INITIALIZED_AND_ENQUEUE(self, async_coroutine)
+
+
 async def _patched_map_messages(
     self, messages: list[ModelMessage]
-) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
     """Patched _map_messages with proper BinaryContent/vision support."""
     litellm_messages: list[dict[str, Any]] = []
 
@@ -115,9 +147,17 @@ async def _patched_map_messages(
                 assistant_message["tool_calls"] = tool_calls
             litellm_messages.append(assistant_message)
 
-    return litellm_messages
+    # Merge all system parts into one message (some providers, e.g. Qwen, reject
+    # multiple system messages even when they appear at the start).
+    system_parts = [msg["content"] for msg in litellm_messages if msg.get("role") == "system"]
+    non_system_messages = [msg for msg in litellm_messages if msg.get("role") != "system"]
+    if system_parts:
+        merged_system = {"role": "system", "content": "\n\n".join(system_parts)}
+        return [merged_system, *non_system_messages]
+    return non_system_messages
 
 
 def apply():
-    """Apply the vision patch to LiteLLMModel."""
-    LiteLLMModel._map_messages = _patched_map_messages
+    """Apply local LiteLLM / pydantic-ai compatibility patches."""
+    setattr(LiteLLMModel, "_map_messages", _patched_map_messages)
+    setattr(LoggingWorker, "ensure_initialized_and_enqueue", _patched_ensure_initialized_and_enqueue)

--- a/src/hr_breaker/models/__init__.py
+++ b/src/hr_breaker/models/__init__.py
@@ -1,3 +1,18 @@
+from .feedback import FilterResult, ValidationResult, GeneratedPDF
+from .iteration import IterationContext
+from .job_posting import JobPosting
+from .language import Language, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, get_language, get_language_safe, LANGUAGE_MODES, resolve_target_language
+from .profile import (
+    Profile,
+    ProfileDocument,
+    RankedProfileDocument,
+    DocumentExtraction,
+    ExperienceEntry,
+    EducationEntry,
+    PersonalInfo,
+    ProjectEntry,
+    SkillsEntry,
+)
 from .resume import ResumeSource, OptimizedResume
 from .resume_data import (
     ResumeData,
@@ -7,10 +22,6 @@ from .resume_data import (
     Education,
     Project,
 )
-from .job_posting import JobPosting
-from .feedback import FilterResult, ValidationResult, GeneratedPDF
-from .iteration import IterationContext
-from .language import Language, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, LANGUAGE_MODES, get_language, get_language_safe, resolve_target_language
 
 __all__ = [
     "ResumeSource",
@@ -29,8 +40,17 @@ __all__ = [
     "Language",
     "SUPPORTED_LANGUAGES",
     "DEFAULT_LANGUAGE",
-    "LANGUAGE_MODES",
     "get_language",
     "get_language_safe",
+    "LANGUAGE_MODES",
     "resolve_target_language",
+    "Profile",
+    "ProfileDocument",
+    "RankedProfileDocument",
+    "DocumentExtraction",
+    "ExperienceEntry",
+    "EducationEntry",
+    "PersonalInfo",
+    "ProjectEntry",
+    "SkillsEntry",
 ]

--- a/src/hr_breaker/models/profile.py
+++ b/src/hr_breaker/models/profile.py
@@ -1,0 +1,176 @@
+import hashlib
+from datetime import datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, computed_field
+
+DocumentKind = Literal["resume", "pdf", "note", "paper", "other"]
+
+
+class Profile(BaseModel):
+    """Persisted archive profile for a single candidate."""
+
+    id: str
+    display_name: str
+    first_name: str | None = None
+    last_name: str | None = None
+    instructions: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    @computed_field
+    @property
+    def full_name(self) -> str | None:
+        parts = [part for part in (self.first_name, self.last_name) if part]
+        if not parts:
+            return None
+        return " ".join(parts)
+
+
+class ProfileDocument(BaseModel):
+    """Normalized document stored within a profile archive."""
+
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    profile_id: str
+    kind: DocumentKind = "other"
+    title: str
+    source_name: str
+    source_url: str | None = None
+    mime_type: str | None = None
+    content_text: str
+    included_by_default: bool = True
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    @computed_field
+    @property
+    def checksum(self) -> str:
+        return hashlib.sha256(self.content_text.encode("utf-8")).hexdigest()
+
+    @computed_field
+    @property
+    def preview_text(self) -> str:
+        collapsed = " ".join(self.content_text.split())
+        if len(collapsed) <= 180:
+            return collapsed
+        return f"{collapsed[:177]}..."
+
+
+class RankedProfileDocument(BaseModel):
+    """Profile document scored against a job posting."""
+
+    document: ProfileDocument
+    lexical_score: float
+    keyword_score: float
+    vector_score: float | None = None
+    score: float
+    snippet: str
+
+
+# --- Extraction models ---
+
+class ExperienceEntry(BaseModel):
+    employer: str
+    title: str
+    start: str
+    end: str
+    bullets: list[str] = Field(default_factory=list)
+
+
+class EducationEntry(BaseModel):
+    institution: str
+    degree: str
+    field: str | None = None
+    start: str | None = None
+    end: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class ProjectEntry(BaseModel):
+    name: str
+    description: str
+    url: str | None = None
+    bullets: list[str] = Field(default_factory=list)
+
+
+class SkillsEntry(BaseModel):
+    technical: list[str] = Field(default_factory=list)
+    languages: list[str] = Field(default_factory=list)
+    certifications: list[str] = Field(default_factory=list)
+    awards: list[str] = Field(default_factory=list)
+
+
+class PersonalInfo(BaseModel):
+    name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    linkedin: str | None = None
+    github: str | None = None
+    website: str | None = None
+    other_links: list[str] = Field(default_factory=list)
+
+
+class DocumentExtraction(BaseModel):
+    """Structured facts extracted from a profile document."""
+
+    personal_info: PersonalInfo = Field(default_factory=PersonalInfo)
+    summary: list[str] = Field(default_factory=list)
+    experience: list[ExperienceEntry] = Field(default_factory=list)
+    education: list[EducationEntry] = Field(default_factory=list)
+    skills: SkillsEntry = Field(default_factory=SkillsEntry)
+    projects: list[ProjectEntry] = Field(default_factory=list)
+    publications: list[str] = Field(default_factory=list)
+
+
+def _has_text(value: str | None) -> bool:
+    return bool(value and value.strip())
+
+
+def extraction_has_signal(extraction: DocumentExtraction) -> bool:
+    """Return True when extraction contains any usable structured evidence."""
+    personal_info = extraction.personal_info
+    if any(
+        _has_text(value)
+        for value in [
+            personal_info.name,
+            personal_info.email,
+            personal_info.phone,
+            personal_info.linkedin,
+            personal_info.github,
+            personal_info.website,
+        ]
+    ):
+        return True
+    if any(_has_text(link) for link in personal_info.other_links):
+        return True
+    if any(_has_text(item) for item in extraction.summary):
+        return True
+    if extraction.experience or extraction.education or extraction.projects:
+        return True
+    if any(_has_text(item) for item in extraction.publications):
+        return True
+    skills = extraction.skills
+    return any([skills.technical, skills.languages, skills.certifications, skills.awards])
+
+
+def get_document_extraction(doc: ProfileDocument) -> DocumentExtraction | None:
+    """Return only authoritative extraction data for a document."""
+    status = str(doc.metadata.get("extraction_status") or "").lower()
+    if status in {"failed", "empty"}:
+        return None
+    raw = doc.metadata.get("extraction")
+    if not raw:
+        return None
+    try:
+        extraction = DocumentExtraction.model_validate(raw)
+    except Exception:
+        return None
+    return extraction if extraction_has_signal(extraction) else None
+
+
+def document_needs_extraction(doc: ProfileDocument) -> bool:
+    status = str(doc.metadata.get("extraction_status") or "").lower()
+    if status in {"failed", "empty"}:
+        return True
+    return get_document_extraction(doc) is None

--- a/src/hr_breaker/models/resume.py
+++ b/src/hr_breaker/models/resume.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -6,6 +7,19 @@ from typing import Any
 from pydantic import BaseModel, Field, computed_field, model_validator
 
 from hr_breaker.models.resume_data import ResumeData
+
+
+_PROFILE_HEADER_RE = re.compile(r"^Profile:\s*(.+)$", re.MULTILINE)
+
+
+def _legacy_profile_name(content: Any) -> str | None:
+    if not isinstance(content, str):
+        return None
+    match = _PROFILE_HEADER_RE.search(content)
+    if match is None:
+        return None
+    profile_name = match.group(1).strip()
+    return profile_name or None
 
 
 class ResumeSource(BaseModel):
@@ -17,6 +31,9 @@ class ResumeSource(BaseModel):
     last_name: str | None = None
     language_code: str = "en"
     filename: str | None = None  # Original upload filename
+    source_type: str | None = None  # upload | paste | profile
+    source_profile_id: str | None = None
+    source_profile_name: str | None = None
     instructions: str | None = None
 
     @model_validator(mode="before")
@@ -30,6 +47,12 @@ class ResumeSource(BaseModel):
                 data["instructions"] = data.pop("notes")
             if "language_code" not in data:
                 data["language_code"] = "en"
+            legacy_profile_name = _legacy_profile_name(data.get("content"))
+            if legacy_profile_name is not None:
+                data.setdefault("source_type", "profile")
+                data.setdefault("source_profile_name", legacy_profile_name)
+            # Drop removed field from old cache files
+            data.pop("contact_info", None)
         return data
 
     # Legacy alias for backward compatibility

--- a/src/hr_breaker/orchestration.py
+++ b/src/hr_breaker/orchestration.py
@@ -1,4 +1,4 @@
-"""Core optimization loop - used by both CLI and Streamlit."""
+"""Core optimization loop - used by both CLI and server."""
 
 import asyncio
 import time
@@ -38,6 +38,24 @@ _ = (
     VectorSimilarityMatcher,
     HallucinationChecker,
 )
+
+
+def _provider_for_model(model_name: str) -> str:
+    return model_name.split("/", 1)[0] if "/" in model_name else "unknown"
+
+
+def _optimization_settings_summary_lines(settings, *, max_iterations: int, parallel: bool, no_shame: bool) -> list[str]:
+    return [
+        f"Pro model: {settings.pro_model} / {_provider_for_model(settings.pro_model)}",
+        f"Flash model: {settings.flash_model} / {_provider_for_model(settings.flash_model)}",
+        f"Embedding model: {settings.embedding_model} / {_provider_for_model(settings.embedding_model)}",
+        f"Optimization mode: {'parallel' if parallel else 'sequential'}, reasoning: {settings.reasoning_effort}, max iterations: {max_iterations}, no-shame: {no_shame}",
+    ]
+
+def _optimizer_changes_log_message(changes: list[str]) -> str:
+    if not changes:
+        return "Optimizer changes: none"
+    return "Optimizer changes:\n" + "\n".join(f"- {change}" for change in changes)
 
 
 @contextmanager
@@ -137,17 +155,24 @@ async def optimize_for_job(
         parallel: Run filters in parallel
         no_shame: Lenient mode
         user_instructions: Optional user instructions for the optimizer
-        language: Target language for resume output (None = English, generated directly in target language)
+        language: Target language for resume output
+        source_language: Source language of the original resume
 
     Returns:
         (optimized_resume, validation_result, job_posting)
     """
     settings = get_settings()
 
-    logger.info("Starting optimization with settings: %s", settings)
-
     if max_iterations is None:
         max_iterations = settings.max_iterations
+
+    for line in _optimization_settings_summary_lines(
+        settings,
+        max_iterations=max_iterations,
+        parallel=parallel,
+        no_shame=no_shame,
+    ):
+        logger.info(line)
 
     renderer = HTMLRenderer()
 
@@ -173,7 +198,7 @@ async def optimize_for_job(
         )
         with log_time("optimize_resume"):
             optimized = await optimize_resume(source, job, ctx, no_shame=no_shame, user_instructions=user_instructions, language=language)
-        logger.info(f"Optimizer changes: {optimized.changes}")
+        logger.info(_optimizer_changes_log_message(optimized.changes))
         # Store last attempt for feedback (html or data depending on mode)
         last_attempt = (
             optimized.html

--- a/src/hr_breaker/server.py
+++ b/src/hr_breaker/server.py
@@ -24,7 +24,8 @@ from hr_breaker.models import (
     LANGUAGE_MODES,
     get_language_safe,
     resolve_target_language,
-)
+ )
+from hr_breaker.models.profile import ProfileDocument
 from hr_breaker.orchestration import optimize_for_job
 from hr_breaker.services import (
     PDFStorage,
@@ -129,6 +130,7 @@ class ProfileActionRequest(LLMOverrideRequest):
 
 class SynthesizeProfileRequest(ProfileActionRequest):
     job_text: str | None = None
+    selected_doc_ids: list[str] | None = None
 
 
 class AddNoteRequest(BaseModel):
@@ -387,6 +389,7 @@ async def get_profile(profile_id: str):
             "id": d.id,
             "title": d.title,
             "kind": d.kind,
+            "included_by_default": d.included_by_default,
             "extraction_status": d.metadata.get("extraction_status", "pending"),
         }
         for d in documents
@@ -434,10 +437,12 @@ async def add_profile_document(
 @app.delete("/api/profile/{profile_id}/document/{doc_id}")
 async def delete_profile_document(profile_id: str, doc_id: str):
     from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
     store = ProfileStore()
     doc = store.get_document(profile_id, doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail="Document not found")
+    extraction_worker.cancel([doc_id])
     store.remove_document(profile_id, doc_id)
     return {"ok": True}
 
@@ -483,11 +488,7 @@ async def re_extract_profile(profile_id: str, req: ProfileActionRequest | None =
     documents = store.list_documents(profile_id)
     doc_ids = [d.id for d in documents]
     overrides = _build_overrides(req or ProfileActionRequest())
-    # Reset statuses so they get re-submitted even if previously done/error
-    with extraction_worker._lock:
-        for doc_id in doc_ids:
-            extraction_worker._status.pop(doc_id, None)
-    extraction_worker.submit(profile_id, doc_ids, overrides=overrides or None)
+    extraction_worker.resubmit(profile_id, doc_ids, overrides=overrides or None)
     return {"submitted": len(doc_ids)}
 
 
@@ -505,9 +506,14 @@ async def synthesize_profile(profile_id: str, req: SynthesizeProfileRequest):
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
 
-    documents = store.list_documents(profile_id)
-    if not documents:
+    all_documents = store.list_documents(profile_id)
+    if not all_documents:
         return JSONResponse(status_code=400, content={"error": "Profile has no documents"})
+
+    try:
+        documents = _resolve_synthesis_documents(all_documents, req.selected_doc_ids)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
 
     overrides = _build_overrides(req)
     try:
@@ -713,6 +719,30 @@ def _broadcast(msg: str | None) -> None:
         return
     for sub_queue in _active_optimization.get("subscribers", []):
         sub_queue.put_nowait(msg)
+
+
+def _default_synthesis_documents(documents: list[ProfileDocument]) -> list[ProfileDocument]:
+    selected = [document for document in documents if document.included_by_default]
+    return selected or documents
+
+
+def _resolve_synthesis_documents(
+    documents: list[ProfileDocument],
+    selected_doc_ids: list[str] | None,
+ ) -> list[ProfileDocument]:
+    if selected_doc_ids is None:
+        return _default_synthesis_documents(documents)
+
+    requested_ids = list(dict.fromkeys(selected_doc_ids))
+    if not requested_ids:
+        raise ValueError("Select at least one document for synthesis")
+
+    documents_by_id = {document.id: document for document in documents}
+    unknown_ids = [doc_id for doc_id in requested_ids if doc_id not in documents_by_id]
+    if unknown_ids:
+        raise ValueError("Unknown profile documents in synthesis scope")
+
+    return [documents_by_id[doc_id] for doc_id in requested_ids]
 
 
 def _build_overrides(req: BaseModel | None) -> dict:

--- a/src/hr_breaker/server.py
+++ b/src/hr_breaker/server.py
@@ -189,10 +189,12 @@ async def upload_resume(
     except Exception as e:
         return JSONResponse(status_code=400, content={"error": f"Failed to read file: {e}"})
 
-    req = _request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json)
     try:
+        req = _request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json)
         with settings_override(_build_overrides(req)):
             first_name, last_name, language_code = await extract_name(content)
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": f"Failed to extract name: {e}"})
 
@@ -429,7 +431,10 @@ async def add_profile_document(
     except Exception as e:
         return JSONResponse(status_code=400, content={"error": f"Failed to read file: {e}"})
 
-    overrides = _build_overrides(_request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json))
+    try:
+        overrides = _build_overrides(_request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json))
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     extraction_worker.submit(profile_id, [doc.id], overrides=overrides or None)
     return {"id": doc.id, "title": doc.title, "kind": doc.kind}
 
@@ -794,9 +799,15 @@ def _request_from_form(
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
     if api_keys_json:
-        payload["api_keys"] = json.loads(api_keys_json)
+        try:
+            payload["api_keys"] = json.loads(api_keys_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid api_keys_json: {exc.msg}") from exc
     if providers_json:
-        payload["providers"] = json.loads(providers_json)
+        try:
+            payload["providers"] = json.loads(providers_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid providers_json: {exc.msg}") from exc
     if content is not None:
         payload["content"] = content
     if job_text is not None:

--- a/src/hr_breaker/server.py
+++ b/src/hr_breaker/server.py
@@ -10,10 +10,11 @@ import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
 from fastapi.responses import FileResponse, StreamingResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+from pydantic_ai.exceptions import ModelHTTPError
 
 from hr_breaker.agents import extract_name, parse_job_posting
 from hr_breaker.config import get_settings, logger, settings_override
@@ -33,6 +34,8 @@ from hr_breaker.services import (
     ScrapingError,
     CloudflareBlockedError,
 )
+from hr_breaker.utils.optimization_telemetry import accumulate_usage_totals, telemetry_reporter, zero_usage_totals
+
 from hr_breaker.services.pdf_storage import generate_run_id
 from hr_breaker.services.pdf_parser import load_resume_content_from_upload
 
@@ -65,7 +68,20 @@ app = FastAPI(title="HR-Breaker")
 
 # --- API Models ---
 
-class PasteResumeRequest(BaseModel):
+class ProviderOverride(BaseModel):
+    provider: str | None = None
+    base_url: str | None = None
+
+
+class LLMOverrideRequest(BaseModel):
+    flash_model: str | None = None
+    embedding_model: str | None = None
+    reasoning_effort: str | None = None
+    api_keys: dict[str, str] | None = None
+    providers: dict[str, ProviderOverride] | None = None
+
+
+class PasteResumeRequest(LLMOverrideRequest):
     content: str
 
 
@@ -92,7 +108,32 @@ class OptimizeRequest(BaseModel):
     embedding_model: str | None = None
     reasoning_effort: str | None = None
     api_keys: dict[str, str] | None = None
+    providers: dict[str, ProviderOverride] | None = None
     filter_thresholds: dict[str, float] | None = None
+
+
+class ProviderCheckRequest(BaseModel):
+    provider: str  # gemini | openrouter | openai | custom
+    api_key: str | None = None
+    base_url: str | None = None
+
+
+class CreateProfileRequest(BaseModel):
+    name: str
+    instructions: str | None = None
+
+
+class ProfileActionRequest(LLMOverrideRequest):
+    pass
+
+
+class SynthesizeProfileRequest(ProfileActionRequest):
+    job_text: str | None = None
+
+
+class AddNoteRequest(BaseModel):
+    title: str
+    content: str
 
 
 # --- Endpoints ---
@@ -133,19 +174,27 @@ async def get_app_settings():
 
 
 @app.post("/api/resume/upload")
-async def upload_resume(file: UploadFile = File(...)):
+async def upload_resume(
+    file: UploadFile = File(...),
+    flash_model: str | None = Form(None),
+    reasoning_effort: str | None = Form(None),
+    api_keys_json: str | None = Form(None),
+    providers_json: str | None = Form(None),
+):
     data = await file.read()
     try:
         content = load_resume_content_from_upload(file.filename, data)
     except Exception as e:
         return JSONResponse(status_code=400, content={"error": f"Failed to read file: {e}"})
 
+    req = _request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json)
     try:
-        first_name, last_name, language_code = await extract_name(content)
+        with settings_override(_build_overrides(req)):
+            first_name, last_name, language_code = await extract_name(content)
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": f"Failed to extract name: {e}"})
 
-    source = ResumeSource(content=content, first_name=first_name, last_name=last_name, language_code=language_code, filename=file.filename)
+    source = ResumeSource(content=content, first_name=first_name, last_name=last_name, language_code=language_code, filename=file.filename, source_type="upload")
 
     # Cache
     ResumeCache().put(source)
@@ -164,11 +213,12 @@ async def paste_resume(req: PasteResumeRequest):
         raise HTTPException(status_code=400, detail="Empty content")
 
     try:
-        first_name, last_name, language_code = await extract_name(content)
+        with settings_override(_build_overrides(req)):
+            first_name, last_name, language_code = await extract_name(content)
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": f"Failed to extract name: {e}"})
 
-    source = ResumeSource(content=content, first_name=first_name, last_name=last_name, language_code=language_code, filename="pasted")
+    source = ResumeSource(content=content, first_name=first_name, last_name=last_name, language_code=language_code, filename="pasted", source_type="paste")
 
     ResumeCache().put(source)
 
@@ -202,6 +252,9 @@ async def cached_resumes():
             "instructions": r.instructions,
             "filename": r.filename,
             "timestamp": r.timestamp.isoformat(),
+            "source_type": r.source_type,
+            "source_profile_id": r.source_profile_id,
+            "source_profile_name": r.source_profile_name,
         }
         for r in resumes
     ]
@@ -269,6 +322,212 @@ async def delete_cached_job(checksum: str):
     JobCache().delete(checksum)
     return {"ok": True}
 
+
+# --- Provider endpoints ---
+
+@app.post("/api/providers/check")
+async def check_provider(req: ProviderCheckRequest):
+    from hr_breaker.services.llm_providers import fetch_provider_catalog
+    result = await fetch_provider_catalog(
+        provider=req.provider,
+        api_key=req.api_key,
+        base_url=req.base_url,
+    )
+    return result
+
+
+# --- Profile endpoints ---
+
+@app.get("/api/profile/")
+async def list_profiles():
+    from hr_breaker.services.profile_store import ProfileStore
+    store = ProfileStore()
+    profiles = store.list_profiles()
+    return [
+        {
+            "id": p.id,
+            "display_name": p.display_name or p.id,
+            "document_count": len(store.list_documents(p.id)),
+            "created_at": p.created_at.isoformat() if p.created_at else None,
+        }
+        for p in profiles
+    ]
+
+
+@app.post("/api/profile/")
+async def create_profile(req: CreateProfileRequest):
+    from hr_breaker.services.profile_store import ProfileStore
+    store = ProfileStore()
+    profile = store.create_profile(display_name=req.name, instructions=req.instructions)
+    return {"id": profile.id, "display_name": profile.display_name}
+
+
+@app.delete("/api/profile/{profile_id}")
+async def delete_profile(profile_id: str):
+    from hr_breaker.services.profile_store import ProfileStore
+    store = ProfileStore()
+    profile = store.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    store.delete_profile(profile_id)
+    return {"ok": True}
+
+
+@app.get("/api/profile/{profile_id}")
+async def get_profile(profile_id: str):
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    profile = store.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    documents = store.list_documents(profile_id)
+    docs = [
+        {
+            "id": d.id,
+            "title": d.title,
+            "kind": d.kind,
+            "extraction_status": d.metadata.get("extraction_status", "pending"),
+        }
+        for d in documents
+    ]
+    active_doc_ids = [
+        d.id for d in documents
+        if extraction_worker.get_status(d.id) in ("pending", "running")
+    ]
+    return {
+        "id": profile.id,
+        "name": profile.display_name,
+        "instructions": profile.instructions,
+        "documents": docs,
+        "extracting": active_doc_ids,
+    }
+
+
+@app.post("/api/profile/{profile_id}/document")
+async def add_profile_document(
+    profile_id: str,
+    file: UploadFile = File(...),
+    flash_model: str | None = Form(None),
+    reasoning_effort: str | None = Form(None),
+    api_keys_json: str | None = Form(None),
+    providers_json: str | None = Form(None),
+):
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    profile = store.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    data = await file.read()
+    try:
+        doc = store.add_upload(profile_id, filename=file.filename, data=data)
+    except Exception as e:
+        return JSONResponse(status_code=400, content={"error": f"Failed to read file: {e}"})
+
+    overrides = _build_overrides(_request_from_form(flash_model, reasoning_effort, api_keys_json, providers_json))
+    extraction_worker.submit(profile_id, [doc.id], overrides=overrides or None)
+    return {"id": doc.id, "title": doc.title, "kind": doc.kind}
+
+
+@app.delete("/api/profile/{profile_id}/document/{doc_id}")
+async def delete_profile_document(profile_id: str, doc_id: str):
+    from hr_breaker.services.profile_store import ProfileStore
+    store = ProfileStore()
+    doc = store.get_document(profile_id, doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    store.remove_document(profile_id, doc_id)
+    return {"ok": True}
+
+
+@app.post("/api/profile/{profile_id}/note")
+async def add_profile_note(profile_id: str, req: AddNoteRequest):
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    if not store.get_profile(profile_id):
+        raise HTTPException(status_code=404, detail="Profile not found")
+    doc = store.add_note(profile_id, title=req.title.strip(), content_text=req.content.strip())
+    extraction_worker.submit(profile_id, [doc.id])
+    return {"id": doc.id, "title": doc.title, "kind": doc.kind}
+
+
+@app.get("/api/profile/{profile_id}/extraction-status")
+async def profile_extraction_status(profile_id: str):
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    profile = store.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    documents = store.list_documents(profile_id)
+    statuses = {
+        d.id: extraction_worker.get_status(d.id) or d.metadata.get("extraction_status", "pending")
+        for d in documents
+    }
+    logs = extraction_worker.drain_logs()
+    active = any(s in ("pending", "running") for s in statuses.values())
+    return {"statuses": statuses, "logs": logs, "active": active}
+
+
+@app.post("/api/profile/{profile_id}/extract")
+async def re_extract_profile(profile_id: str, req: ProfileActionRequest | None = None):
+    """Re-submit all profile documents for background extraction."""
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    if not store.get_profile(profile_id):
+        raise HTTPException(status_code=404, detail="Profile not found")
+    documents = store.list_documents(profile_id)
+    doc_ids = [d.id for d in documents]
+    overrides = _build_overrides(req or ProfileActionRequest())
+    # Reset statuses so they get re-submitted even if previously done/error
+    with extraction_worker._lock:
+        for doc_id in doc_ids:
+            extraction_worker._status.pop(doc_id, None)
+    extraction_worker.submit(profile_id, doc_ids, overrides=overrides or None)
+    return {"submitted": len(doc_ids)}
+
+
+@app.post("/api/profile/{profile_id}/synthesize")
+async def synthesize_profile(profile_id: str, req: SynthesizeProfileRequest):
+    """Synthesize profile into a ResumeSource, cache it, and return the checksum."""
+    from hr_breaker.models.job_posting import JobPosting
+    from hr_breaker.services.profile_retrieval import (
+        rank_profile_documents,
+        synthesize_profile_resume_source,
+    )
+    from hr_breaker.services.profile_store import ProfileStore
+    store = ProfileStore()
+    profile = store.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    documents = store.list_documents(profile_id)
+    if not documents:
+        return JSONResponse(status_code=400, content={"error": "Profile has no documents"})
+
+    overrides = _build_overrides(req)
+    try:
+        with settings_override(overrides):
+            job_text = req.job_text or ""
+            job = JobPosting(title="", company="", raw_text=job_text, description=job_text)
+            ranked = await rank_profile_documents(documents, job)
+            source = synthesize_profile_resume_source(profile, documents, ranked).model_copy(update={"source_type": "profile", "source_profile_id": profile.id, "source_profile_name": profile.display_name})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": f"Synthesis failed: {e}"})
+
+    ResumeCache().put(source)
+    return {
+        "checksum": source.checksum,
+        "first_name": source.first_name,
+        "last_name": source.last_name,
+    }
+
+
+# --- Optimization ---
 
 def _sse_event(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
@@ -412,6 +671,41 @@ async def optimization_status():
     }
 
 
+def _selected_optimization_models(req: OptimizeRequest) -> list[str]:
+    return [model for model in (req.pro_model, req.flash_model, req.embedding_model) if model]
+
+
+def _selected_custom_provider_bases(req: OptimizeRequest) -> list[str]:
+    selected: list[str] = []
+    for scope in ("pro", "flash", "embedding"):
+        override = (req.providers or {}).get(scope)
+        if override and override.provider == "custom" and override.base_url:
+            selected.append(f"{scope}: {override.base_url}")
+    return selected
+
+
+def _normalize_optimization_error(exc: Exception, req: OptimizeRequest) -> str:
+    if isinstance(exc, ModelHTTPError):
+        text = str(exc)
+        if (
+            exc.status_code == 500
+            and "APIConnectionError" in text
+            and "argument of type 'NoneType' is not iterable" in text
+        ):
+            models = ", ".join(_selected_optimization_models(req)) or "the selected models"
+            custom_bases = _selected_custom_provider_bases(req)
+            if custom_bases:
+                return (
+                    f"Custom OpenAI-compatible provider request failed before the model returned a usable response. "
+                    f"Check the base URL configuration ({'; '.join(custom_bases)}), API key, and that the endpoint supports models: {models}."
+                )
+            return (
+                f"OpenAI-compatible provider request failed before the model returned a usable response. "
+                f"Check the API key, provider configuration, and model compatibility for: {models}."
+            )
+    return str(exc)
+
+
 def _broadcast(msg: str | None) -> None:
     """Send a message to all subscriber queues (for reconnected clients)."""
     global _active_optimization
@@ -421,20 +715,23 @@ def _broadcast(msg: str | None) -> None:
         sub_queue.put_nowait(msg)
 
 
-def _build_overrides(req: OptimizeRequest) -> dict:
+def _build_overrides(req: BaseModel | None) -> dict:
     """Build settings override dict from request fields."""
-    overrides = {}
-    if req.pro_model:
-        overrides["pro_model"] = req.pro_model
-    if req.flash_model:
-        overrides["flash_model"] = req.flash_model
-    if req.embedding_model:
-        overrides["embedding_model"] = req.embedding_model
-    if req.reasoning_effort:
-        overrides["reasoning_effort"] = req.reasoning_effort
-    if req.api_keys:
-        overrides["api_keys"] = req.api_keys
-    if req.filter_thresholds:
+    data = req.model_dump(exclude_none=True) if req is not None else {}
+    overrides: dict = {}
+    for field in ("pro_model", "flash_model", "embedding_model", "reasoning_effort", "api_keys"):
+        if field in data:
+            overrides[field] = data[field]
+    for scope, field_name in (
+        ("pro", "pro_openai_api_base"),
+        ("flash", "flash_openai_api_base"),
+        ("embedding", "embedding_openai_api_base"),
+    ):
+        provider_override = (data.get("providers") or {}).get(scope) or {}
+        if provider_override.get("provider") == "custom" and provider_override.get("base_url"):
+            overrides[field_name] = provider_override["base_url"]
+    filter_thresholds = data.get("filter_thresholds")
+    if filter_thresholds:
         threshold_map = {
             "hallucination": "filter_hallucination_threshold",
             "keyword": "filter_keyword_threshold",
@@ -443,10 +740,39 @@ def _build_overrides(req: OptimizeRequest) -> dict:
             "ai_generated": "filter_ai_generated_threshold",
             "translation": "filter_translation_threshold",
         }
-        for short_name, value in req.filter_thresholds.items():
+        for short_name, value in filter_thresholds.items():
             if short_name in threshold_map:
                 overrides[threshold_map[short_name]] = value
     return overrides
+
+def _request_from_form(
+    flash_model: str | None,
+    reasoning_effort: str | None,
+    api_keys_json: str | None,
+    providers_json: str | None,
+    *,
+    embedding_model: str | None = None,
+    content: str | None = None,
+    job_text: str | None = None,
+    request_cls: type[LLMOverrideRequest] = ProfileActionRequest,
+ ) -> LLMOverrideRequest:
+    payload: dict = {}
+    if flash_model:
+        payload["flash_model"] = flash_model
+    if embedding_model:
+        payload["embedding_model"] = embedding_model
+    if reasoning_effort:
+        payload["reasoning_effort"] = reasoning_effort
+    if api_keys_json:
+        payload["api_keys"] = json.loads(api_keys_json)
+    if providers_json:
+        payload["providers"] = json.loads(providers_json)
+    if content is not None:
+        payload["content"] = content
+    if job_text is not None:
+        payload["job_text"] = job_text
+    return request_cls(**payload)
+
 
 
 async def _run_optimization(req: OptimizeRequest, source: ResumeSource):
@@ -459,9 +785,16 @@ async def _run_optimization(req: OptimizeRequest, source: ResumeSource):
 async def _run_optimization_inner(req: OptimizeRequest, source: ResumeSource):
     global _active_optimization
 
+    usage_totals = zero_usage_totals()
+
+    def emit_usage(entry: dict) -> None:
+        nonlocal usage_totals
+        usage_totals = accumulate_usage_totals(usage_totals, entry)
+        _emit("usage", {"entry": entry, "totals": usage_totals})
+
     # Attach SSE log handler so backend logs stream to the UI
     sse_handler = _SSELogHandler()
-    sse_handler.setFormatter(logging.Formatter("%(message)s"))
+    sse_handler.setFormatter(logging.Formatter("%(asctime)s.%(msecs)03d %(message)s", "%H:%M:%S"))
     root_logger = logging.getLogger("hr_breaker")
     original_level = root_logger.level
     root_logger.addHandler(sse_handler)
@@ -477,45 +810,97 @@ async def _run_optimization_inner(req: OptimizeRequest, source: ResumeSource):
 
         _emit("status", {"message": "Parsing job posting..."})
 
-        job = await parse_job_posting(req.job_text)
+        with telemetry_reporter(emit_usage):
+            job = await parse_job_posting(req.job_text)
 
-        # Resolve language mode to concrete languages
-        target_language = resolve_target_language(req.language, job.language_code, source.language_code)
-        source_lang = get_language_safe(source.language_code)
-        lang_code = target_language.code
+            # Resolve language mode to concrete languages
+            target_language = resolve_target_language(req.language, job.language_code, source.language_code)
+            source_lang = get_language_safe(source.language_code)
+            lang_code = target_language.code
 
-        _emit("status", {
-            "message": f"Job: {job.title} at {job.company} "
-            f"(resume: {source_lang.english_name}, job: {get_language_safe(job.language_code).english_name}, "
-            f"target: {target_language.english_name})"
-        })
+            _emit("status", {
+                "message": f"Job: {job.title} at {job.company} "
+                f"(resume: {source_lang.english_name}, job: {get_language_safe(job.language_code).english_name}, "
+                f"target: {target_language.english_name})"
+            })
 
-        # Setup debug dir
-        debug_dir = None
-        if req.debug:
-            debug_dir = pdf_storage.generate_debug_dir(job.company, job.title, run_id=run_id)
+            # Setup debug dir
+            debug_dir = None
+            if req.debug:
+                debug_dir = pdf_storage.generate_debug_dir(job.company, job.title, run_id=run_id)
 
-        max_iterations = req.max_iterations or settings.max_iterations
+            max_iterations = req.max_iterations or settings.max_iterations
 
-        mode = "sequential" if req.sequential else "parallel"
-        _emit("status", {"message": f"Optimizing (mode: {mode}, max: {max_iterations})..."})
+            mode = "sequential" if req.sequential else "parallel"
+            _emit("status", {"message": f"Optimizing (mode: {mode}, max: {max_iterations})..."})
 
-        # Update instructions on source if provided
-        if req.instructions:
-            source = source.model_copy(update={"instructions": req.instructions})
-            cache = ResumeCache()
-            cache.put(source)
+            # Update instructions on source if provided
+            if req.instructions:
+                source = source.model_copy(update={"instructions": req.instructions})
+                cache = ResumeCache()
+                cache.put(source)
 
-        def on_iteration(i, optimized, validation):
-            # Save debug files
-            if req.debug and debug_dir:
-                if optimized.html:
-                    (debug_dir / f"iteration_{i + 1}.html").write_text(optimized.html, encoding="utf-8")
-                if optimized.pdf_bytes:
-                    (debug_dir / f"iteration_{i + 1}.pdf").write_bytes(optimized.pdf_bytes)
+            def on_iteration(i, optimized, validation):
+                if req.debug and debug_dir:
+                    if optimized.html:
+                        (debug_dir / f"iteration_{i + 1}.html").write_text(optimized.html, encoding="utf-8")
+                    if optimized.pdf_bytes:
+                        (debug_dir / f"iteration_{i + 1}.pdf").write_bytes(optimized.pdf_bytes)
 
-            # Send iteration event
-            results_data = [
+                results_data = [
+                    {
+                        "filter_name": r.filter_name,
+                        "passed": r.passed,
+                        "score": r.score,
+                        "threshold": r.threshold,
+                        "skipped": r.skipped,
+                        "issues": r.issues,
+                        "suggestions": r.suggestions,
+                    }
+                    for r in validation.results
+                ]
+                _emit("iteration", {
+                    "iteration": i + 1,
+                    "max_iterations": max_iterations,
+                    "passed": validation.passed,
+                    "changes": optimized.changes,
+                    "results": results_data,
+                })
+
+            optimized, validation, _ = await optimize_for_job(
+                source,
+                max_iterations=max_iterations,
+                on_iteration=on_iteration,
+                job=job,
+                parallel=not req.sequential,
+                no_shame=req.no_shame,
+                user_instructions=req.instructions,
+                language=target_language,
+                source_language=source_lang,
+            )
+
+            pdf_filename = None
+            if optimized and optimized.pdf_bytes:
+                pdf_path = pdf_storage.generate_path(
+                    source.first_name, source.last_name, job.company, job.title,
+                    lang_code=lang_code,
+                    run_id=run_id,
+                )
+                pdf_path.parent.mkdir(parents=True, exist_ok=True)
+                pdf_path.write_bytes(optimized.pdf_bytes)
+                pdf_filename = pdf_path.name
+
+                pdf_record = GeneratedPDF(
+                    path=pdf_path,
+                    source_checksum=source.checksum,
+                    company=job.company,
+                    job_title=job.title,
+                    first_name=source.first_name,
+                    last_name=source.last_name,
+                )
+                pdf_storage.save_record(pdf_record)
+
+            final_results = [
                 {
                     "filter_name": r.filter_name,
                     "passed": r.passed,
@@ -527,74 +912,21 @@ async def _run_optimization_inner(req: OptimizeRequest, source: ResumeSource):
                 }
                 for r in validation.results
             ]
-            _emit("iteration", {
-                "iteration": i + 1,
-                "max_iterations": max_iterations,
+            _emit("complete", {
+                "pdf_filename": pdf_filename,
                 "passed": validation.passed,
-                "changes": optimized.changes,
-                "results": results_data,
+                "validation": final_results,
+                "job": {"title": job.title, "company": job.company},
             })
-
-        optimized, validation, _ = await optimize_for_job(
-            source,
-            max_iterations=max_iterations,
-            on_iteration=on_iteration,
-            job=job,
-            parallel=not req.sequential,
-            no_shame=req.no_shame,
-            user_instructions=req.instructions,
-            language=target_language,
-            source_language=source_lang,
-        )
-
-        # Save PDF
-        pdf_filename = None
-        if optimized and optimized.pdf_bytes:
-            pdf_path = pdf_storage.generate_path(
-                source.first_name, source.last_name, job.company, job.title,
-                lang_code=lang_code,
-                run_id=run_id,
-            )
-            pdf_path.parent.mkdir(parents=True, exist_ok=True)
-            pdf_path.write_bytes(optimized.pdf_bytes)
-            pdf_filename = pdf_path.name
-
-            pdf_record = GeneratedPDF(
-                path=pdf_path,
-                source_checksum=source.checksum,
-                company=job.company,
-                job_title=job.title,
-                first_name=source.first_name,
-                last_name=source.last_name,
-            )
-            pdf_storage.save_record(pdf_record)
-
-        # Final results
-        final_results = [
-            {
-                "filter_name": r.filter_name,
-                "passed": r.passed,
-                "score": r.score,
-                "threshold": r.threshold,
-                "skipped": r.skipped,
-                "issues": r.issues,
-                "suggestions": r.suggestions,
-            }
-            for r in validation.results
-        ]
-        _emit("complete", {
-            "pdf_filename": pdf_filename,
-            "passed": validation.passed,
-            "validation": final_results,
-            "job": {"title": job.title, "company": job.company},
-        })
 
     except asyncio.CancelledError:
         _emit("cancelled", {"message": "Optimization cancelled by user"})
         raise
     except Exception as e:
-        logger.exception("Optimization error")
-        _emit("error", {"message": str(e)})
+        message = _normalize_optimization_error(e, req)
+        logger.error("Optimization error: %s", message)
+        logger.debug("Optimization error details", exc_info=True)
+        _emit("error", {"message": message})
     finally:
         # Detach SSE log handler and restore original level
         root_logger.removeHandler(sse_handler)

--- a/src/hr_breaker/services/__init__.py
+++ b/src/hr_breaker/services/__init__.py
@@ -1,5 +1,5 @@
-from .job_scraper import scrape_job_posting, ScrapingError, CloudflareBlockedError
 from .cache import ResumeCache, JobCache
+from .job_scraper import scrape_job_posting, ScrapingError, CloudflareBlockedError
 from .pdf_storage import PDFStorage
 from .renderer import get_renderer, BaseRenderer, HTMLRenderer, RenderError
 

--- a/src/hr_breaker/services/cache.py
+++ b/src/hr_breaker/services/cache.py
@@ -47,7 +47,7 @@ class ResumeCache:
 
     def list_all(self) -> list[ResumeSource]:
         resumes = []
-        paths = sorted(self.cache_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
+        paths = sorted(self.cache_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
         for path in paths:
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
@@ -100,7 +100,7 @@ class JobCache:
 
     def list_all(self) -> list[dict]:
         jobs = []
-        paths = sorted(self.cache_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
+        paths = sorted(self.cache_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
         for path in paths:
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))

--- a/src/hr_breaker/services/extraction_worker.py
+++ b/src/hr_breaker/services/extraction_worker.py
@@ -1,0 +1,86 @@
+"""Background extraction worker — module-level singleton."""
+import asyncio
+import logging
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+DocStatus = Literal["pending", "running", "done", "error"]
+
+
+class ExtractionWorker:
+    def __init__(self, max_workers: int = 2):
+        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="extractor")
+        self._status: dict[str, DocStatus] = {}
+        self._lock = threading.Lock()
+        self.log_queue: queue.Queue[dict] = queue.Queue()
+
+    def submit(self, profile_id: str, doc_ids: list[str], overrides: dict | None = None) -> None:
+        """Queue documents for background extraction. Already-active jobs are skipped."""
+        job_overrides = dict(overrides or {})
+        with self._lock:
+            for doc_id in doc_ids:
+                if self._status.get(doc_id) not in ("pending", "running"):
+                    self._status[doc_id] = "pending"
+                    self._executor.submit(self._run, profile_id, doc_id, job_overrides)
+
+    def get_status(self, doc_id: str) -> DocStatus | None:
+        with self._lock:
+            return self._status.get(doc_id)
+
+    def any_active(self) -> bool:
+        with self._lock:
+            return any(s in ("pending", "running") for s in self._status.values())
+
+    def drain_logs(self) -> list[dict]:
+        """Return and clear all queued log messages."""
+        events = []
+        while True:
+            try:
+                events.append(self.log_queue.get_nowait())
+            except queue.Empty:
+                break
+        return events
+
+    def _run(self, profile_id: str, doc_id: str, overrides: dict | None = None) -> None:
+        from hr_breaker.config import settings_override
+        from hr_breaker.services.profile_store import ProfileStore
+
+        store = ProfileStore()
+        doc = store.get_document(profile_id, doc_id)
+        label = doc.title if doc else doc_id
+
+        with self._lock:
+            self._status[doc_id] = "running"
+        self.log_queue.put({"level": "INFO", "message": f"Extracting: {label}"})
+
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                with settings_override(overrides):
+                    loop.run_until_complete(store.extract_document_content(profile_id, doc_id))
+            finally:
+                loop.close()
+            # Warn when the LLM returned an empty extraction so the user knows
+            # this doc will fall back to raw-text inclusion in synthesis.
+            updated_doc = store.get_document(profile_id, doc_id)
+            if updated_doc is not None:
+                status = str(updated_doc.metadata.get("extraction_status") or "").lower()
+                if status == "empty":
+                    logger.warning("Extraction for '%s' produced no usable content", label)
+                    self.log_queue.put({"level": "WARNING", "message": f"Extraction empty (no content found): {label}"})
+            with self._lock:
+                self._status[doc_id] = "done"
+            self.log_queue.put({"level": "INFO", "message": f"Extracted: {label}"})
+        except Exception as exc:
+            with self._lock:
+                self._status[doc_id] = "error"
+            self.log_queue.put({"level": "ERROR", "message": f"Extraction failed ({label}): {exc}"})
+            logger.error("Extraction failed for '%s': %s", label, exc)
+
+
+# Module-level singleton
+extraction_worker = ExtractionWorker()

--- a/src/hr_breaker/services/extraction_worker.py
+++ b/src/hr_breaker/services/extraction_worker.py
@@ -15,6 +15,7 @@ class ExtractionWorker:
     def __init__(self, max_workers: int = 2):
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="extractor")
         self._status: dict[str, DocStatus] = {}
+        self._cancelled_doc_ids: set[str] = set()
         self._lock = threading.Lock()
         self.log_queue: queue.Queue[dict] = queue.Queue()
 
@@ -22,10 +23,39 @@ class ExtractionWorker:
         """Queue documents for background extraction. Already-active jobs are skipped."""
         job_overrides = dict(overrides or {})
         with self._lock:
+            self._submit_locked(profile_id, doc_ids, job_overrides, reset_finished=False)
+
+    def resubmit(self, profile_id: str, doc_ids: list[str], overrides: dict | None = None) -> None:
+        """Re-queue finished documents without exposing worker internals to callers."""
+        job_overrides = dict(overrides or {})
+        with self._lock:
+            self._submit_locked(profile_id, doc_ids, job_overrides, reset_finished=True)
+
+    def cancel(self, doc_ids: list[str]) -> None:
+        """Cancel queued status tracking for documents that were deleted."""
+        with self._lock:
             for doc_id in doc_ids:
-                if self._status.get(doc_id) not in ("pending", "running"):
-                    self._status[doc_id] = "pending"
-                    self._executor.submit(self._run, profile_id, doc_id, job_overrides)
+                self._cancelled_doc_ids.add(doc_id)
+                self._status.pop(doc_id, None)
+
+    def _submit_locked(
+        self,
+        profile_id: str,
+        doc_ids: list[str],
+        overrides: dict,
+        *,
+        reset_finished: bool,
+    ) -> None:
+        for doc_id in doc_ids:
+            status = self._status.get(doc_id)
+            if reset_finished and status in ("done", "error"):
+                self._status.pop(doc_id, None)
+                status = None
+            self._cancelled_doc_ids.discard(doc_id)
+            if status in ("pending", "running"):
+                continue
+            self._status[doc_id] = "pending"
+            self._executor.submit(self._run, profile_id, doc_id, overrides)
 
     def get_status(self, doc_id: str) -> DocStatus | None:
         with self._lock:
@@ -54,6 +84,9 @@ class ExtractionWorker:
         label = doc.title if doc else doc_id
 
         with self._lock:
+            if doc_id in self._cancelled_doc_ids:
+                self._status.pop(doc_id, None)
+                return
             self._status[doc_id] = "running"
         self.log_queue.put({"level": "INFO", "message": f"Extracting: {label}"})
 
@@ -61,17 +94,20 @@ class ExtractionWorker:
             loop = asyncio.new_event_loop()
             try:
                 with settings_override(overrides):
-                    loop.run_until_complete(store.extract_document_content(profile_id, doc_id))
+                    updated_doc = loop.run_until_complete(store.extract_document_content(profile_id, doc_id))
             finally:
                 loop.close()
-            # Warn when the LLM returned an empty extraction so the user knows
-            # this doc will fall back to raw-text inclusion in synthesis.
-            updated_doc = store.get_document(profile_id, doc_id)
-            if updated_doc is not None:
-                status = str(updated_doc.metadata.get("extraction_status") or "").lower()
-                if status == "empty":
-                    logger.warning("Extraction for '%s' produced no usable content", label)
-                    self.log_queue.put({"level": "WARNING", "message": f"Extraction empty (no content found): {label}"})
+
+            if updated_doc is None:
+                with self._lock:
+                    self._status.pop(doc_id, None)
+                self.log_queue.put({"level": "INFO", "message": f"Skipped deleted document: {label}"})
+                return
+
+            status = str(updated_doc.metadata.get("extraction_status") or "").lower()
+            if status == "empty":
+                logger.warning("Extraction for '%s' produced no usable content", label)
+                self.log_queue.put({"level": "WARNING", "message": f"Extraction empty (no content found): {label}"})
             with self._lock:
                 self._status[doc_id] = "done"
             self.log_queue.put({"level": "INFO", "message": f"Extracted: {label}"})

--- a/src/hr_breaker/services/llm_providers.py
+++ b/src/hr_breaker/services/llm_providers.py
@@ -123,10 +123,17 @@ async def _fetch_gemini_models(api_key: str) -> tuple[list[dict], list[dict]]:
 
     return _dedup_sort(chat), _dedup_sort(embed)
 
+def _anthropic_models_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return f"{normalized}/models"
+    return f"{normalized}/v1/models"
+
+
 async def _fetch_anthropic_models(api_key: str, base_url: str) -> tuple[list[dict], list[dict]]:
     async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
         resp = await client.get(
-            f"{base_url.rstrip('/')}/v1/models",
+            _anthropic_models_url(base_url),
             headers={
                 "x-api-key": api_key,
                 "anthropic-version": "2023-06-01",

--- a/src/hr_breaker/services/llm_providers.py
+++ b/src/hr_breaker/services/llm_providers.py
@@ -1,0 +1,205 @@
+"""LLM provider model discovery via async HTTP."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+GEMINI_MODELS_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+REQUEST_TIMEOUT = 10.0
+
+CHAT_METHODS = {"generateContent", "streamGenerateContent"}
+EMBEDDING_METHODS = {"embedContent", "batchEmbedContents"}
+
+# Maps provider short name -> (env var for API key, default base URL or None)
+_PROVIDER_CONFIG: dict[str, tuple[str, str | None]] = {
+    "gemini": ("GEMINI_API_KEY", None),
+    "openrouter": ("OPENROUTER_API_KEY", "https://openrouter.ai/api/v1"),
+    "openai": ("OPENAI_API_KEY", "https://api.openai.com/v1"),
+    "anthropic": ("ANTHROPIC_API_KEY", "https://api.anthropic.com"),
+    "moonshot": ("MOONSHOT_API_KEY", "https://api.moonshot.ai/v1"),
+    "custom": ("OPENAI_API_KEY", "https://api.openai.com/v1"),
+}
+
+
+async def fetch_provider_catalog(
+    provider: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    """Discover available models for a provider.
+
+    Returns dict with keys: status, chat_models, embedding_models.
+    """
+    env_var, default_base = _PROVIDER_CONFIG.get(provider, ("", None))
+    resolved_key = (api_key or "").strip() or os.environ.get(env_var, "").strip()
+
+    if not resolved_key:
+        # Also check GOOGLE_API_KEY fallback for gemini
+        if provider == "gemini":
+            resolved_key = os.environ.get("GOOGLE_API_KEY", "").strip()
+
+    if not resolved_key:
+        return {
+            "status": {"state": "unknown", "message": "Enter API key to load models"},
+            "chat_models": [],
+            "embedding_models": [],
+        }
+
+    try:
+        if provider == "gemini":
+            chat, embed = await _fetch_gemini_models(resolved_key)
+        elif provider == "anthropic":
+            resolved_base = (base_url or "").strip() or default_base or "https://api.anthropic.com"
+            chat, embed = await _fetch_anthropic_models(resolved_key, resolved_base)
+        else:
+            resolved_base = (base_url or "").strip() or default_base or "https://api.openai.com/v1"
+            resolved_base = resolved_base.rstrip("/")
+            chat, embed = await _fetch_openai_models(
+                resolved_key, resolved_base, litellm_prefix=_litellm_prefix(provider)
+            )
+    except httpx.HTTPStatusError as exc:
+        detail = _extract_error_detail(exc.response)
+        return {
+            "status": {
+                "state": "warning",
+                "message": f"Connection failed ({exc.response.status_code})",
+                "detail": detail,
+            },
+            "chat_models": [],
+            "embedding_models": [],
+        }
+    except (httpx.RequestError, ValueError) as exc:
+        return {
+            "status": {"state": "warning", "message": "Connection failed", "detail": str(exc)},
+            "chat_models": [],
+            "embedding_models": [],
+        }
+
+    return {
+        "status": {
+            "state": "connected",
+            "message": f"Connected \u00b7 {len(chat)} chat / {len(embed)} embedding",
+        },
+        "chat_models": chat,
+        "embedding_models": embed,
+    }
+
+
+def _litellm_prefix(provider: str) -> str:
+    return {
+        "gemini": "gemini/",
+        "openrouter": "openrouter/",
+        "openai": "openai/",
+        "moonshot": "moonshot/",
+    }.get(provider, "openai/")
+
+
+async def _fetch_gemini_models(api_key: str) -> tuple[list[dict], list[dict]]:
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            GEMINI_MODELS_URL,
+            params={"key": api_key},
+        )
+        resp.raise_for_status()
+        models = resp.json().get("models", [])
+
+    chat: list[dict] = []
+    embed: list[dict] = []
+    for m in models:
+        name = m.get("name", "")
+        if not name:
+            continue
+        short = name.removeprefix("models/")
+        label = m.get("displayName") or short
+        methods = set(m.get("supportedGenerationMethods", []))
+        option = {"value": f"gemini/{short}", "label": str(label)}
+        if methods & CHAT_METHODS:
+            chat.append(option)
+        if methods & EMBEDDING_METHODS:
+            embed.append(option)
+
+    return _dedup_sort(chat), _dedup_sort(embed)
+
+async def _fetch_anthropic_models(api_key: str, base_url: str) -> tuple[list[dict], list[dict]]:
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            f"{base_url.rstrip('/')}/v1/models",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+
+    chat: list[dict] = []
+    for model in data:
+        model_id = model.get("id", "")
+        if not model_id:
+            continue
+        label = model.get("display_name") or model_id
+        chat.append({"value": f"anthropic/{model_id}", "label": str(label)})
+    return _dedup_sort(chat), []
+
+
+async def _fetch_openai_models(
+    api_key: str, base_url: str, litellm_prefix: str
+) -> tuple[list[dict], list[dict]]:
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(
+            f"{base_url}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+
+    chat: list[dict] = []
+    embed: list[dict] = []
+    for m in data:
+        model_id = m.get("id", "")
+        if not model_id:
+            continue
+        if _looks_like_embedding(model_id):
+            embed.append({"value": model_id, "label": model_id})
+        else:
+            chat.append({"value": f"{litellm_prefix}{model_id}", "label": model_id})
+
+    # Fallback: if no chat models found, treat all as chat
+    if not chat and embed:
+        chat = [{"value": f"{litellm_prefix}{e['label']}", "label": e["label"]} for e in embed]
+    # Fallback: if no embedding found, offer all raw
+    if not embed and data:
+        embed = [{"value": m.get("id", ""), "label": m.get("id", "")} for m in data if m.get("id")]
+
+    return _dedup_sort(chat), _dedup_sort(embed)
+
+
+def _looks_like_embedding(model_id: str) -> bool:
+    return "embed" in model_id.lower()
+
+
+def _dedup_sort(options: list[dict]) -> list[dict]:
+    seen: dict[str, dict] = {}
+    for o in options:
+        seen.setdefault(o["value"], o)
+    return sorted(seen.values(), key=lambda o: o["label"].lower())
+
+
+def _extract_error_detail(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text[:200]
+    if isinstance(payload, dict):
+        err = payload.get("error")
+        if isinstance(err, dict):
+            msg = err.get("message")
+            if msg:
+                return str(msg)
+        msg = payload.get("message")
+        if msg:
+            return str(msg)
+    return response.text[:200]

--- a/src/hr_breaker/services/profile_retrieval.py
+++ b/src/hr_breaker/services/profile_retrieval.py
@@ -1,0 +1,103 @@
+"""Profile retrieval — rank documents against a job posting and synthesize resume source.
+
+Public API:
+    rank_profile_documents(documents, job) -> list[RankedProfileDocument]
+    synthesize_profile_resume_source(profile, selected_documents, ranked_documents) -> ResumeSource
+
+Implementation is split across the retrieval/ subpackage:
+    retrieval/lexical.py   — TF-IDF scoring
+    retrieval/vector.py    — embedding scoring with in-memory cache
+    retrieval/snippets.py  — best-line snippet extraction
+    retrieval/merger.py    — extraction merging, formatting, and synthesis
+"""
+
+import logging
+from typing import Iterable
+
+from hr_breaker.config import get_settings
+from hr_breaker.filters.keyword_matcher import check_keywords
+from hr_breaker.models.job_posting import JobPosting
+from hr_breaker.models.profile import Profile, ProfileDocument, RankedProfileDocument
+from hr_breaker.models.resume import ResumeSource
+from hr_breaker.services.retrieval.lexical import lexical_scores as _lexical_scores_fn
+from hr_breaker.services.retrieval.merger import (
+    format_extraction as _format_extraction,
+    merge_extractions as _merge_extractions,
+    synthesize_from_extractions,
+    synthesize_from_whole_docs,
+)
+from hr_breaker.services.retrieval.snippets import build_snippet as _build_snippet_fn
+from hr_breaker.services.retrieval.snippets import _job_text
+from hr_breaker.services.retrieval.vector import vector_scores as _vector_scores_fn
+
+logger = logging.getLogger(__name__)
+
+
+# Keep these as module-level callables so tests can patch
+# `hr_breaker.services.profile_retrieval._vector_scores` / `_lexical_scores`
+def _lexical_scores(job_text: str, documents: list[ProfileDocument]) -> list[float]:
+    return _lexical_scores_fn(job_text, documents)
+
+
+async def _vector_scores(job_text: str, documents: list[ProfileDocument]) -> list[float | None]:
+    return await _vector_scores_fn(job_text, documents)
+
+
+async def rank_profile_documents(
+    documents: Iterable[ProfileDocument],
+    job: JobPosting,
+) -> list[RankedProfileDocument]:
+    """Score every selected document; callers decide how many to display."""
+    selected_documents = list(documents)
+    if not selected_documents:
+        return []
+
+    job_text = _job_text(job)
+    lex_scores = _lexical_scores(job_text, selected_documents)
+    vec_scores = await _vector_scores(job_text, selected_documents)
+
+    ranked: list[RankedProfileDocument] = []
+    for document, lexical_score, vector_score in zip(selected_documents, lex_scores, vec_scores):
+        keyword_score = check_keywords(document.content_text, job, threshold=0.0).score
+        if vector_score is not None:
+            combined_score = lexical_score * 0.65 + keyword_score * 0.2 + vector_score * 0.15
+        else:
+            combined_score = lexical_score * 0.765 + keyword_score * 0.235
+        ranked.append(
+            RankedProfileDocument(
+                document=document,
+                lexical_score=lexical_score,
+                keyword_score=keyword_score,
+                vector_score=vector_score,
+                score=combined_score,
+                snippet=_build_snippet_fn(document, job),
+            )
+        )
+
+    ranked.sort(key=lambda item: (item.score, item.document.timestamp), reverse=True)
+    return ranked
+
+
+def synthesize_profile_resume_source(
+    profile: Profile,
+    selected_documents: Iterable[ProfileDocument],
+    ranked_documents: Iterable[RankedProfileDocument],
+) -> ResumeSource:
+    selected = list(selected_documents)
+    ranked = list(ranked_documents)
+    if not selected:
+        raise ValueError("At least one profile document must be selected")
+
+    header_lines = [f"Profile: {profile.display_name}"]
+    if profile.full_name:
+        header_lines.append(f"Candidate: {profile.full_name}")
+    if profile.instructions:
+        header_lines.extend(["", "Profile instructions:", profile.instructions.strip()])
+    header = "\n".join(header_lines)
+
+    max_chars = get_settings().profile_source_max_chars
+    result = synthesize_from_extractions(profile, selected, ranked, header, max_chars)
+    if result is not None:
+        return result
+
+    return synthesize_from_whole_docs(profile, selected, ranked, header, max_chars)

--- a/src/hr_breaker/services/profile_store.py
+++ b/src/hr_breaker/services/profile_store.py
@@ -250,14 +250,14 @@ class ProfileStore:
         except Exception:
             new_meta = {**doc.metadata, "extraction_status": "failed"}
             failed = doc.model_copy(update={"metadata": new_meta})
-            self._document_path(profile_id, document_id).write_text(
-                failed.model_dump_json(indent=2), encoding="utf-8"
-            )
+            if not self._write_document_if_present(profile_id, document_id, failed):
+                logger.info("Skipping failed extraction persistence for deleted document %s", document_id)
+                return None
             raise
         updated = doc.model_copy(update={"metadata": new_meta})
-        self._document_path(profile_id, document_id).write_text(
-            updated.model_dump_json(indent=2), encoding="utf-8"
-        )
+        if not self._write_document_if_present(profile_id, document_id, updated):
+            logger.info("Skipping extraction persistence for deleted document %s", document_id)
+            return None
         return updated
 
     def remove_document(self, profile_id: str, document_id: str) -> None:
@@ -270,6 +270,24 @@ class ProfileStore:
         profile = self.get_profile(profile_id)
         if profile is not None:
             self.save_profile(profile)
+
+    def _write_document_if_present(
+        self,
+        profile_id: str,
+        document_id: str,
+        document: ProfileDocument,
+    ) -> bool:
+        path = self._document_path(profile_id, document_id)
+        payload = document.model_dump_json(indent=2)
+        try:
+            with path.open("r+", encoding="utf-8") as handle:
+                handle.seek(0)
+                handle.write(payload)
+                handle.truncate()
+        except FileNotFoundError:
+            return False
+        return True
+
 
     def _find_duplicate_document(
         self,

--- a/src/hr_breaker/services/profile_store.py
+++ b/src/hr_breaker/services/profile_store.py
@@ -1,22 +1,28 @@
 import logging
+import os
 import shutil
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from hr_breaker.config import get_settings
-
-logger = logging.getLogger(__name__)
 from hr_breaker.models.profile import DocumentKind, Profile, ProfileDocument
 from hr_breaker.services.pdf_parser import load_resume_content_from_upload
 from hr_breaker.services.pdf_storage import sanitize_filename
+
+logger = logging.getLogger(__name__)
 
 
 class ProfileStore:
     """Persist local profile archives under the cache directory."""
 
+    _path_locks_guard = threading.Lock()
+    _path_locks: dict[str, threading.Lock] = {}
+
     def __init__(self, root_dir: Path | None = None):
-        self.root_dir = root_dir or get_settings().profile_dir
+        self.root_dir = (root_dir or get_settings().profile_dir).resolve()
         self.root_dir.mkdir(parents=True, exist_ok=True)
 
     def list_profiles(self) -> list[Profile]:
@@ -30,7 +36,10 @@ class ProfileStore:
         return sorted(profiles, key=lambda profile: profile.updated_at, reverse=True)
 
     def get_profile(self, profile_id: str) -> Profile | None:
-        path = self._profile_path(profile_id)
+        try:
+            path = self._profile_path(profile_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
         try:
@@ -63,7 +72,10 @@ class ProfileStore:
         profile_dir.mkdir(parents=True, exist_ok=True)
         self._documents_dir(updated.id).mkdir(parents=True, exist_ok=True)
         self._assets_dir(updated.id).mkdir(parents=True, exist_ok=True)
-        self._profile_path(updated.id).write_text(updated.model_dump_json(indent=2), encoding="utf-8")
+        self._write_json_atomically(
+            self._profile_path(updated.id),
+            updated.model_dump_json(indent=2),
+        )
         return updated
 
     def rename_profile(self, profile_id: str, display_name: str) -> Profile | None:
@@ -103,7 +115,11 @@ class ProfileStore:
 
     def list_documents(self, profile_id: str) -> list[ProfileDocument]:
         documents: list[ProfileDocument] = []
-        for path in sorted(self._documents_dir(profile_id).glob("*.json")):
+        try:
+            document_dir = self._documents_dir(profile_id)
+        except ValueError:
+            return []
+        for path in sorted(document_dir.glob("*.json")):
             try:
                 documents.append(ProfileDocument.model_validate_json(path.read_text(encoding="utf-8")))
             except Exception as exc:
@@ -112,7 +128,10 @@ class ProfileStore:
         return sorted(documents, key=lambda document: document.timestamp, reverse=True)
 
     def get_document(self, profile_id: str, document_id: str) -> ProfileDocument | None:
-        path = self._document_path(profile_id, document_id)
+        try:
+            path = self._document_path(profile_id, document_id)
+        except ValueError:
+            return None
         if not path.exists():
             return None
         try:
@@ -229,9 +248,9 @@ class ProfileStore:
                 new_meta["asset_path"] = asset_relative_path
             document = candidate.model_copy(update={"metadata": new_meta})
 
-        self._document_path(profile_id, document.id).write_text(
+        self._write_json_atomically(
+            self._document_path(profile_id, document.id),
             document.model_dump_json(indent=2),
-            encoding="utf-8",
         )
         self.save_profile(profile)
         return document
@@ -262,11 +281,12 @@ class ProfileStore:
 
     def remove_document(self, profile_id: str, document_id: str) -> None:
         path = self._document_path(profile_id, document_id)
-        if path.exists():
-            path.unlink()
-        asset_prefix = f"{document_id}_"
-        for asset_path in self._assets_dir(profile_id).glob(f"{asset_prefix}*"):
-            asset_path.unlink(missing_ok=True)
+        with self._path_lock(path):
+            if path.exists():
+                path.unlink()
+            asset_prefix = f"{document_id}_"
+            for asset_path in self._assets_dir(profile_id).glob(f"{asset_prefix}*"):
+                asset_path.unlink(missing_ok=True)
         profile = self.get_profile(profile_id)
         if profile is not None:
             self.save_profile(profile)
@@ -277,15 +297,39 @@ class ProfileStore:
         document_id: str,
         document: ProfileDocument,
     ) -> bool:
-        path = self._document_path(profile_id, document_id)
-        payload = document.model_dump_json(indent=2)
+        return self._write_json_atomically(
+            self._document_path(profile_id, document_id),
+            document.model_dump_json(indent=2),
+            require_existing=True,
+        )
+
+    @classmethod
+    def _path_lock(cls, path: Path) -> threading.Lock:
+        key = str(path)
+        with cls._path_locks_guard:
+            lock = cls._path_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                cls._path_locks[key] = lock
+            return lock
+
+    def _write_json_atomically(
+        self,
+        path: Path,
+        payload: str,
+        *,
+        require_existing: bool = False,
+    ) -> bool:
+        tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        lock = self._path_lock(path)
         try:
-            with path.open("r+", encoding="utf-8") as handle:
-                handle.seek(0)
-                handle.write(payload)
-                handle.truncate()
-        except FileNotFoundError:
-            return False
+            with lock:
+                if require_existing and not path.exists():
+                    return False
+                tmp_path.write_text(payload, encoding="utf-8")
+                os.replace(tmp_path, path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
         return True
 
 
@@ -337,7 +381,11 @@ class ProfileStore:
         return "other"
 
     def _profile_dir(self, profile_id: str) -> Path:
-        return self.root_dir / profile_id
+        safe_profile_id = self._validate_identifier(profile_id, label="profile_id")
+        path = (self.root_dir / safe_profile_id).resolve()
+        if not path.is_relative_to(self.root_dir):
+            raise ValueError(f"Invalid profile_id: {profile_id}")
+        return path
 
     def _profile_path(self, profile_id: str) -> Path:
         return self._profile_dir(profile_id) / "profile.json"
@@ -349,10 +397,19 @@ class ProfileStore:
         return self._profile_dir(profile_id) / "assets"
 
     def _document_path(self, profile_id: str, document_id: str) -> Path:
-        return self._documents_dir(profile_id) / f"{document_id}.json"
+        safe_document_id = self._validate_identifier(document_id, label="document_id")
+        return self._documents_dir(profile_id) / f"{safe_document_id}.json"
 
     def _asset_path(self, profile_id: str, document_id: str, filename: str) -> Path:
+        safe_document_id = self._validate_identifier(document_id, label="document_id")
         original = Path(filename)
         safe_stem = sanitize_filename(original.stem) or "asset"
-        safe_name = f"{document_id}_{safe_stem}{original.suffix.lower()}"
+        safe_name = f"{safe_document_id}_{safe_stem}{original.suffix.lower()}"
         return self._assets_dir(profile_id) / safe_name
+
+    def _validate_identifier(self, value: str, *, label: str) -> str:
+        if not value or value in {".", ".."}:
+            raise ValueError(f"Invalid {label}: {value}")
+        if Path(value).name != value or "/" in value or "\\" in value:
+            raise ValueError(f"Invalid {label}: {value}")
+        return value

--- a/src/hr_breaker/services/profile_store.py
+++ b/src/hr_breaker/services/profile_store.py
@@ -1,0 +1,340 @@
+import logging
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from hr_breaker.config import get_settings
+
+logger = logging.getLogger(__name__)
+from hr_breaker.models.profile import DocumentKind, Profile, ProfileDocument
+from hr_breaker.services.pdf_parser import load_resume_content_from_upload
+from hr_breaker.services.pdf_storage import sanitize_filename
+
+
+class ProfileStore:
+    """Persist local profile archives under the cache directory."""
+
+    def __init__(self, root_dir: Path | None = None):
+        self.root_dir = root_dir or get_settings().profile_dir
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_profiles(self) -> list[Profile]:
+        profiles: list[Profile] = []
+        for path in sorted(self.root_dir.glob("*/profile.json")):
+            try:
+                profiles.append(Profile.model_validate_json(path.read_text(encoding="utf-8")))
+            except Exception as exc:
+                logger.warning("Skipping corrupt profile file %s: %s", path, exc)
+                continue
+        return sorted(profiles, key=lambda profile: profile.updated_at, reverse=True)
+
+    def get_profile(self, profile_id: str) -> Profile | None:
+        path = self._profile_path(profile_id)
+        if not path.exists():
+            return None
+        try:
+            return Profile.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def create_profile(
+        self,
+        display_name: str,
+        *,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        instructions: str | None = None,
+    ) -> Profile:
+        profile_id = self._unique_profile_id(display_name)
+        profile = Profile(
+            id=profile_id,
+            display_name=display_name.strip(),
+            first_name=first_name,
+            last_name=last_name,
+            instructions=instructions,
+        )
+        self.save_profile(profile)
+        return profile
+
+    def save_profile(self, profile: Profile) -> Profile:
+        updated = profile.model_copy(update={"updated_at": datetime.now()})
+        profile_dir = self._profile_dir(updated.id)
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        self._documents_dir(updated.id).mkdir(parents=True, exist_ok=True)
+        self._assets_dir(updated.id).mkdir(parents=True, exist_ok=True)
+        self._profile_path(updated.id).write_text(updated.model_dump_json(indent=2), encoding="utf-8")
+        return updated
+
+    def rename_profile(self, profile_id: str, display_name: str) -> Profile | None:
+        profile = self.get_profile(profile_id)
+        if profile is None:
+            return None
+        return self.save_profile(profile.model_copy(update={"display_name": display_name.strip()}))
+
+    def update_profile_details(
+        self,
+        profile_id: str,
+        *,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        instructions: str | None = None,
+    ) -> Profile | None:
+        profile = self.get_profile(profile_id)
+        if profile is None:
+            return None
+        return self.save_profile(
+            profile.model_copy(
+                update={
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "instructions": instructions,
+                }
+            )
+        )
+
+    def delete_profile(self, profile_id: str) -> None:
+        profile_dir = self._profile_dir(profile_id)
+        try:
+            shutil.rmtree(profile_dir)
+        except Exception as exc:
+            logger.error("Failed to delete profile directory %s: %s", profile_dir, exc)
+            raise
+
+    def list_documents(self, profile_id: str) -> list[ProfileDocument]:
+        documents: list[ProfileDocument] = []
+        for path in sorted(self._documents_dir(profile_id).glob("*.json")):
+            try:
+                documents.append(ProfileDocument.model_validate_json(path.read_text(encoding="utf-8")))
+            except Exception as exc:
+                logger.warning("Skipping corrupt document file %s: %s", path, exc)
+                continue
+        return sorted(documents, key=lambda document: document.timestamp, reverse=True)
+
+    def get_document(self, profile_id: str, document_id: str) -> ProfileDocument | None:
+        path = self._document_path(profile_id, document_id)
+        if not path.exists():
+            return None
+        try:
+            return ProfileDocument.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def add_upload(
+        self,
+        profile_id: str,
+        *,
+        filename: str,
+        data: bytes,
+        mime_type: str | None = None,
+        title: str | None = None,
+        source_url: str | None = None,
+        included_by_default: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> ProfileDocument:
+        content_text = load_resume_content_from_upload(filename, data)
+        merged_metadata = {
+            "original_filename": filename,
+            "byte_size": len(data),
+            **(metadata or {}),
+        }
+        return self.add_document(
+            profile_id,
+            kind=self._infer_document_kind(filename),
+            title=title or self._default_title(filename),
+            source_name=filename,
+            mime_type=mime_type,
+            content_text=content_text,
+            source_url=source_url,
+            included_by_default=included_by_default,
+            metadata=merged_metadata,
+            asset_bytes=data,
+            asset_filename=filename,
+        )
+
+    def add_note(
+        self,
+        profile_id: str,
+        *,
+        title: str,
+        content_text: str,
+        included_by_default: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> ProfileDocument:
+        return self.add_document(
+            profile_id,
+            kind="note",
+            title=title.strip(),
+            source_name=title.strip(),
+            mime_type="text/plain",
+            content_text=content_text,
+            included_by_default=included_by_default,
+            metadata=metadata,
+        )
+
+    def add_document(
+        self,
+        profile_id: str,
+        *,
+        kind: DocumentKind,
+        title: str,
+        source_name: str,
+        content_text: str,
+        source_url: str | None = None,
+        mime_type: str | None = None,
+        included_by_default: bool = True,
+        metadata: dict[str, Any] | None = None,
+        asset_bytes: bytes | None = None,
+        asset_filename: str | None = None,
+    ) -> ProfileDocument:
+        profile = self.get_profile(profile_id)
+        if profile is None:
+            raise ValueError(f"Unknown profile: {profile_id}")
+
+        candidate = ProfileDocument(
+            profile_id=profile_id,
+            kind=kind,
+            title=title.strip(),
+            source_name=source_name,
+            source_url=source_url,
+            mime_type=mime_type,
+            content_text=content_text,
+            included_by_default=included_by_default,
+            metadata=dict(metadata or {}),
+        )
+        duplicate = self._find_duplicate_document(profile_id, candidate.checksum, candidate.source_name)
+        base = duplicate or candidate
+        asset_relative_path = self._write_asset(profile_id, base.id, asset_filename, asset_bytes)
+
+        if duplicate is not None:
+            new_meta = {**duplicate.metadata, **(metadata or {})}
+            if asset_relative_path is not None:
+                new_meta["asset_path"] = asset_relative_path
+            document = duplicate.model_copy(
+                update={
+                    "kind": kind,
+                    "title": title.strip(),
+                    "source_name": source_name,
+                    "source_url": source_url,
+                    "mime_type": mime_type,
+                    "content_text": content_text,
+                    "included_by_default": included_by_default,
+                    "metadata": new_meta,
+                    "timestamp": datetime.now(),
+                }
+            )
+        else:
+            new_meta = dict(metadata or {})
+            if asset_relative_path is not None:
+                new_meta["asset_path"] = asset_relative_path
+            document = candidate.model_copy(update={"metadata": new_meta})
+
+        self._document_path(profile_id, document.id).write_text(
+            document.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        self.save_profile(profile)
+        return document
+
+    async def extract_document_content(self, profile_id: str, document_id: str) -> ProfileDocument | None:
+        """Run extraction on a document and persist results in its metadata."""
+        doc = self.get_document(profile_id, document_id)
+        if doc is None:
+            return None
+        from hr_breaker.agents.extractor import extract_document
+        from hr_breaker.models.profile import extraction_has_signal
+        try:
+            extraction = await extract_document(doc.content_text)
+            status = "done" if extraction_has_signal(extraction) else "empty"
+            new_meta = {**doc.metadata, "extraction": extraction.model_dump(), "extraction_status": status}
+        except Exception:
+            new_meta = {**doc.metadata, "extraction_status": "failed"}
+            failed = doc.model_copy(update={"metadata": new_meta})
+            self._document_path(profile_id, document_id).write_text(
+                failed.model_dump_json(indent=2), encoding="utf-8"
+            )
+            raise
+        updated = doc.model_copy(update={"metadata": new_meta})
+        self._document_path(profile_id, document_id).write_text(
+            updated.model_dump_json(indent=2), encoding="utf-8"
+        )
+        return updated
+
+    def remove_document(self, profile_id: str, document_id: str) -> None:
+        path = self._document_path(profile_id, document_id)
+        if path.exists():
+            path.unlink()
+        asset_prefix = f"{document_id}_"
+        for asset_path in self._assets_dir(profile_id).glob(f"{asset_prefix}*"):
+            asset_path.unlink(missing_ok=True)
+        profile = self.get_profile(profile_id)
+        if profile is not None:
+            self.save_profile(profile)
+
+    def _find_duplicate_document(
+        self,
+        profile_id: str,
+        checksum: str,
+        source_name: str,
+    ) -> ProfileDocument | None:
+        for document in self.list_documents(profile_id):
+            if document.checksum == checksum and document.source_name == source_name:
+                return document
+        return None
+
+    def _write_asset(
+        self,
+        profile_id: str,
+        document_id: str,
+        filename: str | None,
+        data: bytes | None,
+    ) -> str | None:
+        if filename is None or data is None:
+            return None
+        path = self._asset_path(profile_id, document_id, filename)
+        path.write_bytes(data)
+        return str(path.relative_to(self._profile_dir(profile_id)))
+
+    def _unique_profile_id(self, display_name: str) -> str:
+        base = sanitize_filename(display_name) or "profile"
+        candidate = base
+        index = 2
+        while self._profile_dir(candidate).exists():
+            candidate = f"{base}_{index}"
+            index += 1
+        return candidate
+
+    def _default_title(self, filename: str) -> str:
+        stem = Path(filename).stem.replace("_", " ").replace("-", " ").strip()
+        return stem or filename
+
+    def _infer_document_kind(self, filename: str) -> DocumentKind:
+        lowered = filename.lower()
+        if lowered.endswith(".pdf"):
+            if any(token in lowered for token in ("paper", "publication", "research")):
+                return "paper"
+            return "pdf"
+        if any(token in lowered for token in ("resume", "cv")):
+            return "resume"
+        return "other"
+
+    def _profile_dir(self, profile_id: str) -> Path:
+        return self.root_dir / profile_id
+
+    def _profile_path(self, profile_id: str) -> Path:
+        return self._profile_dir(profile_id) / "profile.json"
+
+    def _documents_dir(self, profile_id: str) -> Path:
+        return self._profile_dir(profile_id) / "documents"
+
+    def _assets_dir(self, profile_id: str) -> Path:
+        return self._profile_dir(profile_id) / "assets"
+
+    def _document_path(self, profile_id: str, document_id: str) -> Path:
+        return self._documents_dir(profile_id) / f"{document_id}.json"
+
+    def _asset_path(self, profile_id: str, document_id: str, filename: str) -> Path:
+        original = Path(filename)
+        safe_stem = sanitize_filename(original.stem) or "asset"
+        safe_name = f"{document_id}_{safe_stem}{original.suffix.lower()}"
+        return self._assets_dir(profile_id) / safe_name

--- a/src/hr_breaker/services/renderer.py
+++ b/src/hr_breaker/services/renderer.py
@@ -45,8 +45,8 @@ class BaseRenderer(ABC):
     """Abstract base class for resume renderers."""
 
     @abstractmethod
-    def render(self, data: ResumeData) -> RenderResult:
-        """Render resume data to PDF."""
+    def render(self, html_body: str) -> RenderResult:
+        """Render resume HTML body to PDF."""
         pass
 
 
@@ -107,19 +107,17 @@ class HTMLRenderer(BaseRenderer):
             raise
 
     def render(self, html_body: str) -> RenderResult:
-        """Render LLM-generated HTML body to PDF.
-
-        Args:
-            html_body: HTML content for the <body> (no wrapper needed)
-        """
+        """Render LLM-generated HTML body to PDF."""
         from weasyprint import HTML
 
-        # Wrap LLM's body content with our template
-        html_content = self._wrapper_html.replace("{{BODY}}", html_body)
+        html_content = (
+            self._wrapper_html
+            .replace("{{HEADER}}", "")
+            .replace("{{BODY}}", html_body)
+        )
 
-        # Render with WeasyPrint
-        html = HTML(string=html_content, base_url=str(TEMPLATE_DIR))
-        doc = html.render(font_config=self.font_config)
+        html_doc = HTML(string=html_content, base_url=str(TEMPLATE_DIR))
+        doc = html_doc.render(font_config=self.font_config)
         pdf_bytes = doc.write_pdf()
         page_count = len(doc.pages)
 
@@ -140,13 +138,13 @@ class HTMLRenderer(BaseRenderer):
         template = self.env.get_template("resume.html")
         html_content = template.render(resume=data)
 
-        html = HTML(string=html_content, base_url=str(TEMPLATE_DIR))
+        html_doc = HTML(string=html_content, base_url=str(TEMPLATE_DIR))
         css_path = TEMPLATE_DIR / "resume.css"
         stylesheets = []
         if css_path.exists():
             stylesheets.append(CSS(filename=str(css_path), font_config=self.font_config))
 
-        doc = html.render(stylesheets=stylesheets, font_config=self.font_config)
+        doc = html_doc.render(stylesheets=stylesheets, font_config=self.font_config)
         pdf_bytes = doc.write_pdf()
         page_count = len(doc.pages)
 

--- a/src/hr_breaker/services/retrieval/lexical.py
+++ b/src/hr_breaker/services/retrieval/lexical.py
@@ -1,0 +1,36 @@
+"""Lexical (TF-IDF) document scoring against a job posting."""
+
+import re
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from hr_breaker.config import get_settings
+from hr_breaker.models.profile import ProfileDocument
+
+_TOKEN_PATTERN = r"(?u)\b[a-zA-Z][a-zA-Z0-9+#.-]*\b"
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def lexical_scores(job_text: str, documents: list[ProfileDocument]) -> list[float]:
+    """Return TF-IDF cosine similarity of each document against job_text."""
+    if not documents:
+        return []
+    corpus = [job_text, *[_normalize_text(document.content_text) for document in documents]]
+    try:
+        vectorizer = TfidfVectorizer(
+            stop_words="english",
+            ngram_range=(1, 2),
+            max_features=get_settings().keyword_tfidf_max_features,
+            token_pattern=_TOKEN_PATTERN,
+        )
+        matrix = vectorizer.fit_transform(corpus)
+    except ValueError:
+        return [0.0 for _ in documents]
+
+    job_vector = matrix[0:1]
+    similarities = cosine_similarity(job_vector, matrix[1:]).flatten()
+    return [float(value) for value in similarities]

--- a/src/hr_breaker/services/retrieval/merger.py
+++ b/src/hr_breaker/services/retrieval/merger.py
@@ -1,0 +1,422 @@
+"""Extraction merging and synthesis — merge multiple DocumentExtractions and format for optimizer."""
+
+import re
+
+from hr_breaker.models.profile import (
+    DocumentExtraction,
+    EducationEntry,
+    ExperienceEntry,
+    PersonalInfo,
+    Profile,
+    ProfileDocument,
+    ProjectEntry,
+    RankedProfileDocument,
+    SkillsEntry,
+    get_document_extraction,
+    extraction_has_signal,
+    document_needs_extraction,
+    )
+from hr_breaker.models.resume import ResumeSource
+
+_MAX_MERGED_SUMMARIES = 2
+
+# Kind priority for whole-doc fallback ordering (lower = higher priority)
+KIND_PRIORITY: dict[str, int] = {
+    "resume": 0,
+    "experience": 1,
+    "education": 2,
+    "bio": 3,
+    "facts": 4,
+    "note": 5,
+    "paper": 6,
+    "pdf": 7,
+    "other": 7,
+}
+
+
+def get_extraction(doc: ProfileDocument) -> DocumentExtraction | None:
+    return get_document_extraction(doc)
+
+
+def _exp_sort_key(e: ExperienceEntry) -> str:
+    end = e.end.lower().strip()
+    if any(w in end for w in ("present", "current", "now")):
+        return "9999"
+    years = re.findall(r"\b(20\d{2}|19\d{2})\b", end)
+    return years[-1] if years else end
+
+
+def _merge_bullets(existing: list[str], incoming: list[str]) -> list[str]:
+    """Union of bullets, preserving order, deduplicating by normalized text."""
+    seen = {" ".join(b.split()).lower() for b in existing}
+    merged = list(existing)
+    for b in incoming:
+        norm = " ".join(b.split()).lower()
+        if norm not in seen:
+            seen.add(norm)
+            merged.append(b)
+    return merged
+
+
+def _merge_exp(existing: ExperienceEntry, incoming: ExperienceEntry) -> ExperienceEntry:
+    """Merge two entries for the same role: union bullets, prefer more specific end date."""
+    merged_bullets = _merge_bullets(existing.bullets, incoming.bullets)
+    # Prefer the end date that sorts later (more recent / more specific)
+    better_end = existing.end if _exp_sort_key(existing) >= _exp_sort_key(incoming) else incoming.end
+    return existing.model_copy(update={"bullets": merged_bullets, "end": better_end})
+
+
+def _merge_edu(existing: EducationEntry, incoming: EducationEntry) -> EducationEntry:
+    """Merge two entries for the same degree: union notes, fill in missing dates/field."""
+    merged_notes = _merge_bullets(existing.notes, incoming.notes)
+    field = existing.field or incoming.field
+    start = existing.start or incoming.start
+    end = existing.end or incoming.end
+    return existing.model_copy(update={"notes": merged_notes, "field": field, "start": start, "end": end})
+
+
+def _merge_proj(existing: ProjectEntry, incoming: ProjectEntry) -> ProjectEntry:
+    """Merge two entries for the same project: union bullets, fill in missing URL."""
+    merged_bullets = _merge_bullets(existing.bullets, incoming.bullets)
+    url = existing.url or incoming.url
+    # Prefer the longer description
+    description = existing.description if len(existing.description) >= len(incoming.description) else incoming.description
+    return existing.model_copy(update={"bullets": merged_bullets, "url": url, "description": description})
+
+
+def merge_extractions(extractions: list[DocumentExtraction]) -> DocumentExtraction:
+    """Merge multiple document extractions, deduplicating by natural key.
+
+    Unlike a simple first-wins approach, overlapping entries (same role, same
+    degree, same project) are merged field-by-field: bullets are unioned,
+    missing dates/fields are filled from the richer source, and end dates are
+    reconciled by preferring the more specific/recent value.
+    """
+    merged_pi = PersonalInfo()
+    seen_other_links: set[str] = set()
+    for ext in extractions:
+        pi = ext.personal_info
+        if not merged_pi.name and pi.name:
+            merged_pi = merged_pi.model_copy(update={"name": pi.name})
+        if not merged_pi.email and pi.email:
+            merged_pi = merged_pi.model_copy(update={"email": pi.email})
+        if not merged_pi.phone and pi.phone:
+            merged_pi = merged_pi.model_copy(update={"phone": pi.phone})
+        if not merged_pi.linkedin and pi.linkedin:
+            merged_pi = merged_pi.model_copy(update={"linkedin": pi.linkedin})
+        if not merged_pi.github and pi.github:
+            merged_pi = merged_pi.model_copy(update={"github": pi.github})
+        if not merged_pi.website and pi.website:
+            merged_pi = merged_pi.model_copy(update={"website": pi.website})
+        for link in pi.other_links:
+            norm = link.strip()
+            if norm and norm not in seen_other_links:
+                seen_other_links.add(norm)
+                merged_pi = merged_pi.model_copy(
+                    update={"other_links": merged_pi.other_links + [norm]}
+                )
+
+    summaries: list[str] = []
+    # Keyed dicts for content-aware merging
+    experience_by_key: dict[tuple, ExperienceEntry] = {}
+    education_by_key: dict[tuple, EducationEntry] = {}
+    projects_by_key: dict[str, ProjectEntry] = {}
+    publications: list[str] = []
+    technical: set[str] = set()
+    languages: set[str] = set()
+    certifications: set[str] = set()
+    awards: set[str] = set()
+
+    seen_summaries: set[str] = set()
+    seen_publications: set[str] = set()
+
+    for ext in extractions:
+        for s in ext.summary:
+            key = " ".join(s.split())
+            if key not in seen_summaries:
+                seen_summaries.add(key)
+                summaries.append(s)
+
+        # TODO: deduplication uses exact-match normalized keys. "Apple Computer Inc." and
+        # "Apple" or "BS" vs "B.S." will not merge, creating duplicate entries. A fuzzy
+        # employer/institution name match (e.g. difflib.SequenceMatcher) would improve
+        # cross-document dedup quality but is deferred to avoid introducing false merges.
+        for exp in ext.experience:
+            key = (exp.employer.lower().strip(), exp.title.lower().strip(), exp.start)
+            if key not in experience_by_key:
+                experience_by_key[key] = exp
+            else:
+                experience_by_key[key] = _merge_exp(experience_by_key[key], exp)
+
+        for edu in ext.education:
+            key = (edu.institution.lower().strip(), edu.degree.lower().strip())
+            if key not in education_by_key:
+                education_by_key[key] = edu
+            else:
+                education_by_key[key] = _merge_edu(education_by_key[key], edu)
+
+        for proj in ext.projects:
+            key = proj.name.lower().strip()
+            if key not in projects_by_key:
+                projects_by_key[key] = proj
+            else:
+                projects_by_key[key] = _merge_proj(projects_by_key[key], proj)
+
+        for pub in ext.publications:
+            key = " ".join(pub.split())
+            if key not in seen_publications:
+                seen_publications.add(key)
+                publications.append(pub)
+
+        technical.update(ext.skills.technical)
+        languages.update(ext.skills.languages)
+        certifications.update(ext.skills.certifications)
+        awards.update(ext.skills.awards)
+
+    experience = sorted(experience_by_key.values(), key=_exp_sort_key, reverse=True)
+
+    return DocumentExtraction(
+        personal_info=merged_pi,
+        summary=summaries[:_MAX_MERGED_SUMMARIES],
+        experience=experience,
+        education=list(education_by_key.values()),
+        skills=SkillsEntry(
+            technical=sorted(technical),
+            languages=sorted(languages),
+            certifications=sorted(certifications),
+            awards=sorted(awards),
+        ),
+        projects=list(projects_by_key.values()),
+        publications=publications,
+    )
+
+
+
+def format_extraction(
+    extraction: DocumentExtraction,
+    ranked: list[RankedProfileDocument] | None = None,
+) -> str:
+    """Render merged extraction as structured plain text for the optimizer."""
+    lines: list[str] = []
+
+    pi = extraction.personal_info
+    if pi.name:
+        lines.append(f"Candidate name: {pi.name}")
+        lines.append("")
+    contact_parts = [p for p in [pi.email, pi.phone, pi.linkedin, pi.github, pi.website] if p]
+    if contact_parts:
+        lines.append("## Contact")
+        lines.extend(contact_parts)
+        lines.append("")
+    if pi.other_links:
+        lines.append("## Additional links (for use inline with projects/publications, not in header)")
+        lines.extend(pi.other_links)
+        lines.append("")
+
+    if ranked:
+        lines.append("## Source documents ranked by relevance to job (prioritize accordingly)")
+        for i, r in enumerate(ranked[:6], 1):
+            lines.append(f"{i}. {r.document.title} (score: {r.score:.2f})")
+        lines.append("")
+
+    if extraction.summary:
+        lines.append("## Summary")
+        for s in extraction.summary:
+            lines.append(s.strip())
+        lines.append("")
+
+    if extraction.experience:
+        lines.append("## Experience")
+        for exp in extraction.experience:
+            lines.append(f"{exp.employer} — {exp.title} | {exp.start} – {exp.end}")
+            for b in exp.bullets:
+                lines.append(f"  • {b}")
+        lines.append("")
+
+    if extraction.education:
+        lines.append("## Education")
+        for edu in extraction.education:
+            parts = [edu.institution, edu.degree]
+            if edu.field:
+                parts.append(edu.field)
+            dates = " – ".join(filter(None, [edu.start, edu.end]))
+            if dates:
+                parts.append(f"| {dates}")
+            lines.append(" ".join(parts))
+            for n in edu.notes:
+                lines.append(f"  {n}")
+        lines.append("")
+
+    skills = extraction.skills
+    if any([skills.technical, skills.languages, skills.certifications, skills.awards]):
+        lines.append("## Skills")
+        if skills.technical:
+            lines.append(f"Technical: {', '.join(skills.technical)}")
+        if skills.languages:
+            lines.append(f"Languages: {', '.join(skills.languages)}")
+        if skills.certifications:
+            lines.append(f"Certifications: {', '.join(skills.certifications)}")
+        if skills.awards:
+            lines.append(f"Awards: {', '.join(skills.awards)}")
+        lines.append("")
+
+    if extraction.projects:
+        lines.append("## Projects")
+        for proj in extraction.projects:
+            header = proj.name
+            if proj.url:
+                header += f" ({proj.url})"
+            lines.append(f"{header} — {proj.description}")
+            for b in proj.bullets:
+                lines.append(f"  • {b}")
+        lines.append("")
+
+    if extraction.publications:
+        lines.append("## Publications")
+        for pub in extraction.publications:
+            lines.append(f"• {pub}")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def split_full_name(name: str | None) -> tuple[str | None, str | None]:
+    if not name:
+        return None, None
+    parts = [part for part in name.strip().split() if part]
+    if not parts:
+        return None, None
+    if len(parts) == 1:
+        return parts[0], None
+    return parts[0], " ".join(parts[1:])
+
+
+def resolve_profile_name_parts(
+    profile: Profile, *, extracted_name: str | None
+ ) -> tuple[str | None, str | None, str | None]:
+    extracted_first, extracted_last = split_full_name(extracted_name)
+    display_first, display_last = split_full_name(profile.display_name)
+
+    first_name = profile.first_name or extracted_first
+    last_name = profile.last_name or extracted_last
+
+    if not first_name and not last_name:
+        first_name, last_name = display_first, display_last
+    elif not first_name and display_last and display_last == last_name:
+        first_name = display_first
+    elif not last_name and display_first and display_first == first_name:
+        last_name = display_last
+
+    best_name = " ".join(part for part in [first_name, last_name] if part) or None
+    return first_name, last_name, best_name
+
+
+def synthesize_from_extractions(
+    profile: Profile,
+    selected: list[ProfileDocument],
+    ranked: list[RankedProfileDocument],
+    header: str,
+    max_chars: int,
+) -> ResumeSource | None:
+    """Synthesize from extracted facts, appending raw text for unextracted docs.
+
+    Returns None only if *no* selected document has extraction data.
+    When some docs lack extraction, their raw text is appended after the
+    structured section (within the char budget) so the optimizer sees all
+    selected evidence.
+    """
+    pairs = [(doc, get_extraction(doc)) for doc in selected]
+    extracted_pairs = [(doc, ext) for doc, ext in pairs if ext is not None]
+    unextracted_docs = [doc for doc, ext in pairs if ext is None]
+
+    if not extracted_pairs:
+        return None
+
+    extracted_exts = [ext for _, ext in extracted_pairs]
+    merged = merge_extractions(extracted_exts)
+
+    # Resolve name before formatting so format_extraction is only called once.
+    extracted_name = merged.personal_info.name or None
+    first_name, last_name, best_name = resolve_profile_name_parts(
+        profile, extracted_name=extracted_name
+    )
+    if best_name and best_name != merged.personal_info.name:
+        merged = merged.model_copy(
+            update={"personal_info": merged.personal_info.model_copy(update={"name": best_name})}
+        )
+
+    body = format_extraction(merged, ranked=ranked or None)
+
+    # Append raw text for unextracted docs within remaining budget
+    if unextracted_docs:
+        used = len(header) + len(body) + 4  # 4 for "\n\n" separators
+        remaining = max_chars - used
+        appended: list[str] = []
+        skipped: list[str] = []
+        score_by_id = {r.document.id: r.score for r in ranked}  # empty dict when ranked=[]
+        # Sort unextracted by relevance score descending so the most relevant fit first
+        unextracted_sorted = sorted(
+            unextracted_docs,
+            key=lambda d: -score_by_id.get(d.id, 0.0),
+        )
+        for doc in unextracted_sorted:
+            section = f"\n\n## {doc.title} [{doc.kind}] (raw — extraction unavailable)\n{doc.content_text.strip()}"
+            if len(section) <= remaining:
+                appended.append(section)
+                remaining -= len(section)
+            else:
+                skipped.append(doc.title)
+        if appended:
+            body += "".join(appended)
+        if skipped:
+            body += f"\n\nNote: extraction unavailable, omitted (over budget): {', '.join(skipped)}"
+
+    return ResumeSource(
+        content=f"{header}\n\n{body}".strip(),
+        first_name=first_name,
+        last_name=last_name,
+        instructions=profile.instructions,
+    )
+
+
+def synthesize_from_whole_docs(
+    profile: Profile,
+    selected: list[ProfileDocument],
+    ranked: list[RankedProfileDocument],
+    header: str,
+    max_chars: int,
+) -> ResumeSource:
+    """Fallback synthesis: load whole documents in priority order up to max_chars budget."""
+    score_by_id = {r.document.id: r.score for r in ranked}
+    ordered = sorted(
+        selected,
+        key=lambda d: (KIND_PRIORITY.get(d.kind, 7), -score_by_id.get(d.id, 0.0)),
+    )
+    budget = max_chars - len(header) - 50
+    included: list[str] = []
+    skipped: list[str] = []
+    remaining = budget
+    for doc in ordered:
+        section = f"\n\n## {doc.title} [{doc.kind}]\n{doc.content_text.strip()}"
+        if len(section) <= remaining:
+            included.append(section)
+            remaining -= len(section)
+        else:
+            skipped.append(doc.title)
+
+    if not included and ordered:
+        top = ordered[0]
+        included.append(f"\n\n## {top.title} [{top.kind}]\n{top.content_text.strip()}")
+        skipped = [d.title for d in ordered[1:]]
+
+    body = "Profile documents:" + "".join(included)
+    if skipped:
+        body += f"\n\nNote: omitted (over budget): {', '.join(skipped)}"
+
+    first_name, last_name, best_name = resolve_profile_name_parts(profile, extracted_name=None)
+    return ResumeSource(
+        content=f"{header}\n\n{body}".strip(),
+        first_name=first_name,
+        last_name=last_name,
+        instructions=profile.instructions,
+    )

--- a/src/hr_breaker/services/retrieval/merger.py
+++ b/src/hr_breaker/services/retrieval/merger.py
@@ -19,18 +19,16 @@ from hr_breaker.models.profile import (
 from hr_breaker.models.resume import ResumeSource
 
 _MAX_MERGED_SUMMARIES = 2
+_WHOLE_DOC_FALLBACK_OVERHEAD_CHARS = 50
 
-# Kind priority for whole-doc fallback ordering (lower = higher priority)
+# Kind priority for whole-doc fallback ordering (lower = higher priority).
+# Keep this aligned with DocumentKind.
 KIND_PRIORITY: dict[str, int] = {
     "resume": 0,
-    "experience": 1,
-    "education": 2,
-    "bio": 3,
-    "facts": 4,
-    "note": 5,
-    "paper": 6,
-    "pdf": 7,
-    "other": 7,
+    "note": 1,
+    "paper": 2,
+    "pdf": 3,
+    "other": 4,
 }
 
 
@@ -392,10 +390,10 @@ def synthesize_from_whole_docs(
         selected,
         key=lambda d: (KIND_PRIORITY.get(d.kind, 7), -score_by_id.get(d.id, 0.0)),
     )
-    budget = max_chars - len(header) - 50
+    budget = max_chars - len(header) - _WHOLE_DOC_FALLBACK_OVERHEAD_CHARS
     included: list[str] = []
     skipped: list[str] = []
-    remaining = budget
+    remaining = max(0, budget)
     for doc in ordered:
         section = f"\n\n## {doc.title} [{doc.kind}]\n{doc.content_text.strip()}"
         if len(section) <= remaining:
@@ -403,11 +401,6 @@ def synthesize_from_whole_docs(
             remaining -= len(section)
         else:
             skipped.append(doc.title)
-
-    if not included and ordered:
-        top = ordered[0]
-        included.append(f"\n\n## {top.title} [{top.kind}]\n{top.content_text.strip()}")
-        skipped = [d.title for d in ordered[1:]]
 
     body = "Profile documents:" + "".join(included)
     if skipped:

--- a/src/hr_breaker/services/retrieval/snippets.py
+++ b/src/hr_breaker/services/retrieval/snippets.py
@@ -1,0 +1,70 @@
+"""Snippet extraction — pick the most relevant lines from a document for display."""
+
+import re
+
+from hr_breaker.config import get_settings
+from hr_breaker.models.job_posting import JobPosting
+from hr_breaker.models.profile import ProfileDocument
+
+_TOKEN_PATTERN = r"(?u)\b[a-zA-Z][a-zA-Z0-9+#.-]*\b"
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _tokenize(value: str) -> set[str]:
+    return set(re.findall(_TOKEN_PATTERN, value.lower()))
+
+
+def _job_text(job: JobPosting) -> str:
+    return "\n".join([
+        f"Title: {job.title}",
+        f"Company: {job.company}",
+        f"Requirements: {', '.join(job.requirements)}",
+        f"Keywords: {', '.join(job.keywords)}",
+        f"Description: {job.description or ''}",
+    ])
+
+
+def _segment_candidates(text: str) -> list[str]:
+    lines = [line.strip(" \t•*-–") for line in text.splitlines()]
+    filtered = [line for line in lines if line]
+    if not filtered:
+        filtered = [chunk.strip() for chunk in re.split(r"\n\s*\n", text) if chunk.strip()]
+    return filtered[:80]
+
+
+def _score_segment(segment: str, job_terms: set[str], keywords: set[str]) -> float:
+    normalized = _normalize_text(segment)
+    if not normalized:
+        return 0.0
+    segment_terms = _tokenize(normalized)
+    if not segment_terms:
+        return 0.0
+    overlap = len(segment_terms & job_terms) / max(len(job_terms), 1)
+    keyword_hits = len(segment_terms & keywords) / max(len(keywords), 1) if keywords else 0.0
+    length_bonus = min(len(normalized), 220) / 2200
+    return overlap * 0.6 + keyword_hits * 0.3 + length_bonus
+
+
+def build_snippet(document: ProfileDocument, job: JobPosting) -> str:
+    segments = _segment_candidates(document.content_text)
+    if not segments:
+        return document.preview_text
+
+    job_terms = _tokenize(_job_text(job))
+    keywords = {keyword.lower() for keyword in job.keywords}
+    scored_segments = [
+        (segment, _score_segment(segment, job_terms, keywords), index)
+        for index, segment in enumerate(segments)
+    ]
+    best = sorted(scored_segments, key=lambda item: (item[1], -item[2]), reverse=True)[:3]
+    ordered = [segment for segment, score, index in sorted(best, key=lambda item: item[2]) if score > 0]
+    if not ordered:
+        ordered = sorted(segments[:10], key=len, reverse=True)[:2]
+    snippet = "\n".join(ordered)
+    max_chars = get_settings().profile_snippet_max_chars
+    if len(snippet) <= max_chars:
+        return snippet
+    return f"{snippet[: max_chars - 3]}..."

--- a/src/hr_breaker/services/retrieval/vector.py
+++ b/src/hr_breaker/services/retrieval/vector.py
@@ -1,0 +1,140 @@
+"""Vector (embedding) document scoring with in-memory cache."""
+
+import hashlib
+import logging
+import threading
+
+from litellm import aembedding as litellm_aembedding
+
+from hr_breaker.config import get_embedding_api_base, get_settings, has_api_key_for_model
+from hr_breaker.models.profile import ProfileDocument
+from hr_breaker.utils.retry import run_with_retry
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache shared across asyncio event loops and background threads.
+# The lock serialises reads/writes to prevent cache corruption under concurrent
+# extraction (ExtractionWorker uses ThreadPoolExecutor).
+_embedding_cache: dict[str, list[float]] = {}
+_cache_lock = threading.Lock()
+
+
+def _cache_key(doc: ProfileDocument) -> str:
+    """Cache key based on doc id + full content hash so stale entries are
+    never returned when a document is re-uploaded with changed content."""
+    content_hash = hashlib.sha256(doc.content_text.encode()).hexdigest()[:16]
+    return f"{doc.id}:{content_hash}"
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _has_embedding_api_key() -> bool:
+    """Check if the configured embedding model has usable credentials."""
+    return has_api_key_for_model(get_settings().embedding_model)
+
+
+async def vector_scores(job_text: str, documents: list[ProfileDocument]) -> list[float | None]:
+    """Return embedding cosine similarity of each document against job_text.
+
+    Returns [None, ...] if no embedding API key is configured or on error.
+    Results for unchanged documents are served from the module-level cache.
+    """
+    if not documents:
+        return []
+    if not _has_embedding_api_key():
+        return [None for _ in documents]
+
+    settings = get_settings()
+    truncated = [_normalize_text(doc.content_text)[:4000] for doc in documents]
+    for doc, text in zip(documents, truncated):
+        if len(_normalize_text(doc.content_text)) > 4000:
+            logger.debug("Truncating document '%s' for embedding", doc.title)
+
+    to_embed_indices: list[int] = []
+    to_embed_texts: list[str] = []
+    cached_embeddings: dict[int, list[float]] = {}
+
+    for i, (doc, text) in enumerate(zip(documents, truncated)):
+        key = _cache_key(doc)
+        with _cache_lock:
+            cached = _embedding_cache.get(key)
+        if cached is not None:
+            cached_embeddings[i] = cached
+        else:
+            to_embed_indices.append(i)
+            to_embed_texts.append(text)
+
+    fresh_embeddings: dict[int, list[float]] = {}
+    api_base = get_embedding_api_base()
+
+    if to_embed_texts:
+        payload = [job_text, *to_embed_texts]
+        try:
+            if api_base:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    dimensions=settings.embedding_output_dimensionality,
+                    api_base=api_base,
+                    input=payload,
+                )
+            else:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    dimensions=settings.embedding_output_dimensionality,
+                    input=payload,
+                )
+        except Exception as exc:
+            logger.warning("Profile retrieval embedding failed: %s", exc)
+            return [None for _ in documents]
+
+        raw = [item["embedding"] for item in result.data]
+        job_embedding = raw[0]
+        for list_idx, (doc_idx, text) in enumerate(zip(to_embed_indices, to_embed_texts)):
+            emb = raw[list_idx + 1]
+            key = _cache_key(documents[doc_idx])
+            with _cache_lock:
+                _embedding_cache[key] = emb
+            fresh_embeddings[doc_idx] = emb
+    else:
+        # All documents were cached; still need job embedding for similarity
+        try:
+            if api_base:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    dimensions=settings.embedding_output_dimensionality,
+                    api_base=api_base,
+                    input=[job_text],
+                )
+            else:
+                result = await run_with_retry(
+                    litellm_aembedding,
+                    model=settings.embedding_model,
+                    dimensions=settings.embedding_output_dimensionality,
+                    input=[job_text],
+                )
+        except Exception as exc:
+            logger.warning("Profile retrieval embedding (job only) failed: %s", exc)
+            return [None for _ in documents]
+        job_embedding = result.data[0]["embedding"]
+
+    scores: list[float | None] = []
+    for i in range(len(documents)):
+        emb = cached_embeddings.get(i) or fresh_embeddings.get(i)
+        if emb is None:
+            scores.append(None)
+            continue
+        dot = sum(left * right for left, right in zip(job_embedding, emb))
+        job_norm = sum(v * v for v in job_embedding) ** 0.5
+        doc_norm = sum(v * v for v in emb) ** 0.5
+        if not job_norm or not doc_norm:
+            # Zero-norm vector means the embedding is degenerate; treat as no signal.
+            scores.append(None)
+            continue
+        similarity = dot / (job_norm * doc_norm)
+        scores.append((similarity + 1) / 2)
+    return scores

--- a/src/hr_breaker/static/css/style.css
+++ b/src/hr_breaker/static/css/style.css
@@ -206,6 +206,10 @@ label {
     transition: border-color 0.15s;
     position: relative;
 }
+.file-drop.file-drop-compact {
+    padding: 10px 16px;
+}
+
 .file-drop:hover, .file-drop.dragover {
     border-color: var(--accent);
 }
@@ -302,6 +306,14 @@ label {
 
 /* --- Cached resume picker --- */
 .cached-resumes { margin-bottom: 8px; }
+.resume-source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 176px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
 .cached-resume-item {
     display: flex;
     flex-direction: column;
@@ -317,6 +329,13 @@ label {
 .cached-resume-item:hover { background: var(--surface-hover); }
 .cached-resume-item .name { font-size: 0.85rem; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .cached-resume-item .meta { font-size: 0.7rem; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.resume-source-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 0 0 auto;
+}
+.btn-icon,
 .btn-remove {
     background: none;
     border: none;
@@ -326,6 +345,7 @@ label {
     line-height: 1;
     padding: 0 2px;
 }
+.btn-icon:hover { color: var(--text); }
 .btn-remove:hover { color: var(--error); }
 
 /* --- Progress/results --- */
@@ -416,9 +436,31 @@ label {
 /* --- API key input row --- */
 .key-input-row { display: flex; gap: 8px; align-items: center; }
 .key-input-row input { flex: 1; }
-.key-status { font-size: 0.7rem; font-weight: 600; min-width: 28px; text-align: center; }
+.key-status { font-size: 1rem; min-width: 16px; text-align: center; }
 .key-set { color: var(--success); }
 .key-unset { color: var(--text-secondary); }
+
+/* --- Connection status --- */
+.connection-status { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; margin: 6px 0; color: var(--text-secondary); }
+.status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+.status-dot.unknown { background: var(--text-secondary); }
+.status-dot.warning { background: var(--warning); }
+.status-dot.connected { background: var(--success); }
+
+/* --- Combobox --- */
+.combobox { position: relative; }
+.combobox-list {
+    position: absolute; top: 100%; left: 0; right: 0; z-index: 20;
+    max-height: 200px; overflow-y: auto;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 0 0 6px 6px;
+    border-top: none;
+}
+.combobox-option {
+    padding: 6px 12px; cursor: pointer; font-size: 0.85rem;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.combobox-option:hover { background: var(--surface-hover); }
+.combobox-empty { padding: 6px 12px; font-size: 0.8rem; color: var(--text-secondary); }
 
 /* --- Threshold slider --- */
 .threshold-row { display: flex; align-items: center; gap: 8px; }
@@ -477,6 +519,15 @@ label {
     user-select: none;
 }
 .log-toggle:hover { color: var(--text); }
+
+.profile-document-list {
+    max-height: 216px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+.profile-document-list .cached-resume-item {
+    flex: 0 0 auto;
+}
 
 .log-panel {
     margin-top: 6px;

--- a/src/hr_breaker/static/index.html
+++ b/src/hr_breaker/static/index.html
@@ -204,10 +204,19 @@
                                             <div x-show="profile.documents.length === 0 && !profile.uploading" class="empty-hint">
                                                 No documents. Upload one above.
                                             </div>
+                                            <div x-show="profile.documents.length > 0" class="meta" style="margin-bottom: 6px">
+                                                <span x-text="selectedProfileDocumentCount() + ' selected for synthesis'"></span>
+                                            </div>
                                             <template x-for="doc in profile.documents" :key="doc.id">
                                                 <div class="cached-resume-item">
-                                                    <div style="display: flex; justify-content: space-between; align-items: center;">
-                                                        <span class="name" x-text="doc.title"></span>
+                                                    <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
+                                                        <label style="display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; cursor: pointer;">
+                                                            <input type="checkbox"
+                                                                   :checked="isProfileDocSelected(doc.id)"
+                                                                   @click.stop
+                                                                   @change="setProfileDocSelected(doc.id, $event.target.checked)">
+                                                            <span class="name" x-text="doc.title"></span>
+                                                        </label>
                                                         <button class="btn-remove" @click.stop="deleteProfileDoc(doc.id)" title="Remove">&times;</button>
                                                     </div>
                                                     <div style="display: flex; gap: 8px; align-items: center;">
@@ -268,7 +277,7 @@
                                             </button>
                                             <button class="btn btn-primary" style="flex: 1"
                                                     @click="synthesizeProfile"
-                                                    :disabled="profile.synthesizing || profile.documents.length === 0">
+                                                    :disabled="profile.synthesizing || selectedProfileDocumentCount() === 0">
                                                 <template x-if="profile.synthesizing"><span class="spinner"></span></template>
                                                 Use as Resume
                                             </button>

--- a/src/hr_breaker/static/index.html
+++ b/src/hr_breaker/static/index.html
@@ -52,21 +52,30 @@
                     <template x-if="!resume.loaded">
                         <div>
                             <!-- Cached resume picker -->
-                            <template x-if="cachedResumes.length > 0">
+                            <template x-if="resumePickerEntries.length > 0">
                                 <div class="cached-resumes">
                                     <label>Previously used</label>
-                                    <template x-for="r in cachedResumes" :key="r.checksum">
-                                        <div class="cached-resume-item" @click="selectCachedResume(r)">
-                                            <div style="display: flex; justify-content: space-between; align-items: baseline;">
-                                                <span class="name" x-text="[r.first_name, r.last_name].filter(Boolean).join(' ') || 'Unknown'"></span>
-                                                <span style="display: flex; align-items: center; gap: 6px;">
-                                                    <span class="meta" x-text="formatShortDate(r.timestamp)"></span>
-                                                    <button class="btn-remove" @click.stop="removeCachedResume(r.checksum)" title="Remove">&times;</button>
-                                                </span>
+                                    <div class="resume-source-list">
+                                        <template x-for="entry in resumePickerEntries" :key="entry.key">
+                                            <div class="cached-resume-item" @click="selectResumeSource(entry)">
+                                                <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 8px;">
+                                                    <span class="name" x-text="entry.name"></span>
+                                                    <span class="resume-source-actions">
+                                                        <template x-if="entry.timestamp">
+                                                            <span class="meta" x-text="formatShortDate(entry.timestamp)"></span>
+                                                        </template>
+                                                        <template x-if="entry.kind === 'profile'">
+                                                            <button class="btn-icon" @click.stop="openProfileEditor(entry.profile)" title="Edit profile">✎</button>
+                                                        </template>
+                                                        <template x-if="entry.kind === 'resume'">
+                                                            <button class="btn-remove" @click.stop="removeCachedResume(entry.resume.checksum)" title="Remove">&times;</button>
+                                                        </template>
+                                                    </span>
+                                                </div>
+                                                <span class="meta" x-text="entry.meta"></span>
                                             </div>
-                                            <span class="meta" x-text="r.filename || 'pasted'"></span>
-                                        </div>
-                                    </template>
+                                        </template>
+                                    </div>
                                     <div style="font-size: 0.75rem; color: var(--text-secondary); margin: 6px 0 4px">Or add new:</div>
                                 </div>
                             </template>
@@ -76,6 +85,8 @@
                                         @click="resume.inputMode = 'upload'">Upload</button>
                                 <button class="tab" :class="resume.inputMode === 'paste' && 'active'"
                                         @click="resume.inputMode = 'paste'">Paste</button>
+                                <button class="tab" :class="resume.inputMode === 'profile' && 'active'"
+                                        @click="resume.inputMode = 'profile'; loadProfiles()">Profile</button>
                             </div>
 
                             <template x-if="resume.inputMode === 'upload'">
@@ -104,6 +115,166 @@
                                         <template x-if="resume.loading"><span class="spinner"></span></template>
                                         Submit
                                     </button>
+                                </div>
+                            </template>
+
+                            <!-- Profile tab -->
+                            <template x-if="resume.inputMode === 'profile'">
+                                <div>
+                                    <!-- Profile list -->
+                                    <div x-show="!profile.selected">
+                                        <div class="action-row" style="margin-bottom: 8px">
+                                            <button class="btn btn-ghost btn-sm" @click="loadProfiles">Refresh</button>
+                                            <button class="btn btn-secondary btn-sm" @click="profile.creating = !profile.creating">
+                                                + New Profile
+                                            </button>
+                                        </div>
+
+                                        <!-- Create profile form -->
+                                        <template x-if="profile.creating">
+                                            <div style="margin-bottom: 10px; padding: 8px; border: 1px solid var(--border); border-radius: 6px;">
+                                                <input type="text" x-model="profile.newName" placeholder="Profile name"
+                                                       style="margin-bottom: 6px" @keydown.enter="createProfile">
+                                                <textarea x-model="profile.newInstructions" placeholder="Instructions (optional)" rows="2"
+                                                          style="margin-bottom: 6px; font-size: 0.85rem"></textarea>
+                                                <div style="display: flex; gap: 6px">
+                                                    <button class="btn btn-secondary btn-sm" @click="createProfile"
+                                                            :disabled="!profile.newName.trim() || profile.loading">
+                                                        <template x-if="profile.loading"><span class="spinner"></span></template>
+                                                        Create
+                                                    </button>
+                                                    <button class="btn btn-ghost btn-sm" @click="profile.creating = false; profile.newName = ''; profile.newInstructions = ''">
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </template>
+
+                                        <div x-show="profile.loading && !profile.creating" style="color: var(--text-secondary); font-size: 0.85rem">
+                                            <span class="spinner"></span> Loading...
+                                        </div>
+                                        <div x-show="profile.error" class="field-error" x-text="profile.error" style="margin-bottom: 8px"></div>
+                                        <div x-show="profile.list.length === 0 && !profile.loading" class="empty-hint">
+                                            No profiles yet. Create one to get started.
+                                        </div>
+                                        <template x-for="p in profile.list" :key="p.id">
+                                            <div class="cached-resume-item" @click="selectProfile(p)">
+                                                <div style="display: flex; justify-content: space-between; align-items: baseline; gap: 8px;">
+                                                    <span class="name" x-text="p.display_name || p.id"></span>
+                                                    <span class="resume-source-actions">
+                                                        <template x-if="profile.activatingId === p.id"><span class="meta">Loading…</span></template>
+                                                        <button class="btn-icon" @click.stop="openProfileEditor(p)" title="Edit profile">✎</button>
+                                                        <button class="btn-remove" @click.stop="deleteProfile(p.id)" title="Delete">&times;</button>
+                                                    </span>
+                                                </div>
+                                                <span class="meta" x-text="(p.document_count || 0) > 0 ? ((p.document_count || 0) + ' document(s) · click to use as resume') : 'No documents yet · click to edit'"></span>
+                                            </div>
+                                        </template>
+                                    </div>
+
+                                    <!-- Selected profile detail -->
+                                    <div x-show="profile.selected">
+                                        <div class="action-row" style="margin-bottom: 8px">
+                                            <button class="btn btn-ghost btn-sm" @click="closeProfileEditor()">
+                                                ← Back
+                                            </button>
+                                            <span class="name" x-text="profile.selected && (profile.selected.display_name || profile.selected.id)"></span>
+                                        </div>
+
+                                        <!-- Upload document -->
+                                        <div class="file-drop file-drop-compact" style="margin-bottom: 8px"
+                                             :class="{'dragover': $el._dragover}"
+                                             @dragover.prevent="$el._dragover = true"
+                                             @dragleave="$el._dragover = false"
+                                             @drop.prevent="$el._dragover = false; uploadProfileDoc({target: {files: $event.dataTransfer.files}})">
+                                            <template x-if="!profile.uploading">
+                                                <div>
+                                                    <div>Add documents</div>
+                                                    <div class="file-hint">.tex .md .txt .pdf</div>
+                                                </div>
+                                            </template>
+                                            <template x-if="profile.uploading">
+                                                <div><span class="spinner"></span> <span x-text="profile.uploadProgress || 'Uploading...'"></span></div>
+                                            </template>
+                                            <input type="file" accept=".tex,.md,.txt,.pdf" multiple @change="uploadProfileDoc($event)">
+                                        </div>
+
+                                        <!-- Document list -->
+                                        <div class="profile-document-list">
+                                            <div x-show="profile.documents.length === 0 && !profile.uploading" class="empty-hint">
+                                                No documents. Upload one above.
+                                            </div>
+                                            <template x-for="doc in profile.documents" :key="doc.id">
+                                                <div class="cached-resume-item">
+                                                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                                                        <span class="name" x-text="doc.title"></span>
+                                                        <button class="btn-remove" @click.stop="deleteProfileDoc(doc.id)" title="Remove">&times;</button>
+                                                    </div>
+                                                    <div style="display: flex; gap: 8px; align-items: center;">
+                                                        <span class="meta" x-text="doc.kind"></span>
+                                                        <span class="meta"
+                                                              :style="doc.extraction_status === 'extracted' ? 'color: var(--success)' : (doc.extraction_status === 'error' ? 'color: var(--error)' : '')"
+                                                              x-text="doc.extraction_status || 'pending'"></span>
+                                                    </div>
+                                                </div>
+                                            </template>
+                                        </div>
+
+                                        <!-- Extraction logs -->
+                                        <div x-show="profile.extractionLogs.length > 0" style="margin-top: 8px">
+                                            <div class="log-toggle" @click="profile.logsOpen = !profile.logsOpen">
+                                                <span x-text="(profile.logsOpen ? 'Hide' : 'Show') + ' extraction logs (' + profile.extractionLogs.length + ')'"></span>
+                                                <span class="chevron" :class="profile.logsOpen && 'open'"></span>
+                                            </div>
+                                            <div x-show="profile.logsOpen" class="log-panel" style="max-height: 120px">
+                                                <template x-for="(log, i) in profile.extractionLogs" :key="i">
+                                                    <div class="log-line">
+                                                        <span class="log-level" :class="'log-' + log.level.toLowerCase()"
+                                                              x-text="log.level.substring(0,4)"></span>
+                                                        <span class="log-msg" x-text="log.message"></span>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                        </div>
+
+                                        <!-- Add note -->
+                                        <div style="margin-top: 8px">
+                                            <button class="btn btn-ghost btn-sm" @click="profile.showNoteForm = !profile.showNoteForm">
+                                                <span x-text="profile.showNoteForm ? '× Cancel note' : '+ Add note'"></span>
+                                            </button>
+                                        </div>
+                                        <template x-if="profile.showNoteForm">
+                                            <div style="margin-top: 6px; padding: 8px; border: 1px solid var(--border); border-radius: 6px;">
+                                                <input type="text" x-model="profile.noteTitle" placeholder="Note title"
+                                                       style="margin-bottom: 6px" @keydown.enter.prevent="$el.nextElementSibling.focus()">
+                                                <textarea x-model="profile.noteContent" placeholder="Note content..." rows="3"
+                                                          style="margin-bottom: 6px; font-size: 0.85rem"></textarea>
+                                                <button class="btn btn-secondary btn-sm"
+                                                        @click="addProfileNote"
+                                                        :disabled="!profile.noteTitle.trim() || profile.addingNote">
+                                                    <template x-if="profile.addingNote"><span class="spinner"></span></template>
+                                                    Add Note
+                                                </button>
+                                            </div>
+                                        </template>
+
+                                        <!-- Re-extract + Synthesize buttons -->
+                                        <div class="action-row" style="margin-top: 10px; gap: 6px">
+                                            <button class="btn btn-ghost btn-sm" style="flex: 0 0 auto"
+                                                    @click="reExtractProfile"
+                                                    :disabled="profile.documents.length === 0"
+                                                    title="Re-run extraction on all documents">
+                                                ↻ Re-extract
+                                            </button>
+                                            <button class="btn btn-primary" style="flex: 1"
+                                                    @click="synthesizeProfile"
+                                                    :disabled="profile.synthesizing || profile.documents.length === 0">
+                                                <template x-if="profile.synthesizing"><span class="spinner"></span></template>
+                                                Use as Resume
+                                            </button>
+                                        </div>
+                                        <div x-show="profile.error" class="field-error" x-text="profile.error"></div>
+                                    </div>
                                 </div>
                             </template>
                         </div>
@@ -220,14 +391,22 @@
                     <span x-text="optimization.statusMessage"></span>
                 </div>
 
+                <template x-if="usageStatusLines().length > 0">
+                    <div style="margin-top: 8px">
+                        <template x-for="(line, i) in usageStatusLines()" :key="i">
+                            <div class="sidebar-hint" x-text="line"></div>
+                        </template>
+                    </div>
+                </template>
+
                 <!-- Log panel -->
-                <div x-show="optimization.logs.length > 0" class="log-section">
+                <div x-show="visibleOptimizationLogs().length > 0" class="log-section">
                     <div class="log-toggle" @click="optimization.logsOpen = !optimization.logsOpen">
-                        <span x-text="(optimization.logsOpen ? 'Hide' : 'Show') + ' logs (' + optimization.logs.length + ')'"></span>
+                        <span x-text="(optimization.logsOpen ? 'Hide' : 'Show') + ' logs (' + visibleOptimizationLogs().length + ')'" ></span>
                         <span class="chevron" :class="optimization.logsOpen && 'open'"></span>
                     </div>
                     <div x-show="optimization.logsOpen" id="log-panel" class="log-panel">
-                        <template x-for="(log, i) in optimization.logs" :key="i">
+                        <template x-for="(log, i) in visibleOptimizationLogs()" :key="i">
                             <div class="log-line">
                                 <span class="log-level" :class="'log-' + log.level.toLowerCase()" x-text="({DEBUG:'DEBUG',INFO:'INFO ',WARNING:'WARN ',ERROR:'ERROR',CRITICAL:'CRIT '}[log.level] || log.level).substring(0,5)"></span>
                                 <span class="log-msg" x-text="log.message"></span>
@@ -361,6 +540,10 @@
                         <label for="opt-debug">Debug mode (save iterations)</label>
                     </div>
                     <div class="setting-row">
+                        <input type="checkbox" id="opt-intermediate" x-model="settings.showIntermediateLogs">
+                        <label for="opt-intermediate">Intermediate logs</label>
+                    </div>
+                    <div class="setting-row">
                         <input type="checkbox" id="opt-shame" x-model="settings.noShame">
                         <label for="opt-shame">No Shame mode</label>
                     </div>
@@ -374,18 +557,130 @@
                     <span class="chevron" :class="drawerSections.models && 'open'"></span>
                 </div>
                 <div class="sidebar-section-body" x-show="drawerSections.models">
-                    <div class="setting-field">
-                        <label for="opt-pro-model">Pro model</label>
-                        <input type="text" id="opt-pro-model" x-model="settings.proModel">
+                    <!-- Provider -->
+                    <div class="tabs" style="margin-bottom: 8px">
+                        <template x-for="scope in providerScopes()" :key="scope">
+                            <button class="tab"
+                                    :class="provider.activeScope === scope && 'active'"
+                                    @click="setProviderScope(scope)"
+                                    x-text="providerTabLabel(scope)"></button>
+                        </template>
                     </div>
                     <div class="setting-field">
-                        <label for="opt-flash-model">Flash model</label>
-                        <input type="text" id="opt-flash-model" x-model="settings.flashModel">
+                        <label for="opt-provider">Provider</label>
+                        <select id="opt-provider" :value="providerSelected()" @change="handleProviderSelectionChange($event.target.value)">
+                            <option value="gemini">Gemini</option>
+                            <option value="openrouter">OpenRouter</option>
+                            <option value="openai">OpenAI</option>
+                            <option value="anthropic">Anthropic</option>
+                            <option value="moonshot">Moonshot AI</option>
+                            <option value="custom">Custom (OpenAI-compatible)</option>
+                        </select>
                     </div>
-                    <div class="setting-field">
-                        <label for="opt-embed-model">Embedding model</label>
-                        <input type="text" id="opt-embed-model" x-model="settings.embeddingModel">
+
+                    <!-- Base URL (custom only) -->
+                    <template x-if="providerSelected() === 'custom'">
+                        <div class="setting-field">
+                            <label for="opt-base-url">Base URL</label>
+                            <input type="text" id="opt-base-url" :value="providerBaseUrl()"
+                                   @input="handleProviderBaseUrlInput($event.target.value)"
+                                   placeholder="https://api.openai.com/v1">
+                        </div>
+                    </template>
+
+                    <!-- Connection status + reload -->
+                    <div class="connection-status">
+                        <span class="status-dot" :class="providerRuntime().status"></span>
+                        <span x-show="providerRuntime().checking" class="spinner" style="width:10px;height:10px;border-width:1.5px;flex-shrink:0"></span>
+                        <span x-text="providerRuntime().message" style="flex:1;font-size:0.78rem"></span>
+                        <button class="btn btn-ghost btn-sm" style="padding:2px 6px;font-size:0.75rem" @click="checkProvider()" :disabled="providerRuntime().checking">↻</button>
                     </div>
+                    <div class="sidebar-hint" style="margin-top:2px">
+                        <span x-text="providerScopeSummary()"></span>
+                        <button x-show="canResetProviderOverride()" class="btn btn-ghost btn-sm" style="margin-left:6px;padding:1px 6px;font-size:0.72rem" @click="resetProviderOverride()">Use Pro provider</button>
+                    </div>
+                    <div class="sidebar-hint" x-show="providerRuntime().detail" x-text="providerRuntime().detail" style="margin-top:2px;word-break:break-word"></div>
+                    <div class="sidebar-hint" style="margin-top:2px">API key set in the <strong>API Keys</strong> section below</div>
+
+                    <!-- Pro model (combobox) -->
+                    <div class="setting-field" x-data="{ open: false, q: '' }">
+                        <label>Pro model</label>
+                        <div class="combobox">
+                            <input type="text"
+                                   :value="open ? q : settings.proModel"
+                                   @focus="q = settings.proModel; open = true"
+                                   @input="q = $event.target.value; open = true"
+                                   @keydown.enter.prevent="settings.proModel = q; open = false; $event.target.blur()"
+                                   @keydown.escape="open = false; $event.target.blur()"
+                                   @blur="setTimeout(() => { if (!settings.proModel && q) settings.proModel = q; open = false }, 150)"
+                                   placeholder="Type or select model...">
+                            <div class="combobox-list" x-show="open && providerChatModels('pro').length > 0">
+                                <template x-for="m in providerChatModels('pro').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                                    <div class="combobox-option"
+                                         @mousedown.prevent="settings.proModel = m.value; q = m.value; open = false"
+                                         x-text="m.label"></div>
+                                </template>
+                                <div class="combobox-empty"
+                                     x-show="q && providerChatModels('pro').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                    No matches — press Enter to use custom value
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Flash model (combobox) -->
+                    <div class="setting-field" x-data="{ open: false, q: '' }">
+                        <label>Flash model</label>
+                        <div class="combobox">
+                            <input type="text"
+                                   :value="open ? q : settings.flashModel"
+                                   @focus="q = settings.flashModel; open = true"
+                                   @input="q = $event.target.value; open = true"
+                                   @keydown.enter.prevent="settings.flashModel = q; open = false; $event.target.blur()"
+                                   @keydown.escape="open = false; $event.target.blur()"
+                                   @blur="setTimeout(() => { if (!settings.flashModel && q) settings.flashModel = q; open = false }, 150)"
+                                   placeholder="Type or select model...">
+                            <div class="combobox-list" x-show="open && providerChatModels('flash').length > 0">
+                                <template x-for="m in providerChatModels('flash').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                                    <div class="combobox-option"
+                                         @mousedown.prevent="settings.flashModel = m.value; q = m.value; open = false"
+                                         x-text="m.label"></div>
+                                </template>
+                                <div class="combobox-empty"
+                                     x-show="q && providerChatModels('flash').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                    No matches — press Enter to use custom value
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Embedding model (combobox) -->
+                    <div class="setting-field" x-data="{ open: false, q: '' }">
+                        <label>Embedding model</label>
+                        <div class="combobox">
+                            <input type="text"
+                                   :value="open ? q : settings.embeddingModel"
+                                   @focus="q = settings.embeddingModel; open = true"
+                                   @input="q = $event.target.value; open = true"
+                                   @keydown.enter.prevent="settings.embeddingModel = q; open = false; $event.target.blur()"
+                                   @keydown.escape="open = false; $event.target.blur()"
+                                   @blur="setTimeout(() => { if (!settings.embeddingModel && q) settings.embeddingModel = q; open = false }, 150)"
+                                   placeholder="Type or select model...">
+                            <div class="combobox-list" x-show="open && providerEmbeddingModels('embedding').length > 0">
+                                <template x-for="m in providerEmbeddingModels('embedding').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                                    <div class="combobox-option"
+                                         @mousedown.prevent="settings.embeddingModel = m.value; q = m.value; open = false"
+                                         x-text="m.label"></div>
+                                </template>
+                                <div class="combobox-empty"
+                                     x-show="q && providerEmbeddingModels('embedding').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                    No matches — press Enter to use custom value
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Reasoning effort -->
                     <div class="setting-field">
                         <label for="opt-reasoning">Reasoning effort</label>
                         <select id="opt-reasoning" x-model="settings.reasoningEffort">
@@ -412,10 +707,14 @@
                             <label x-text="label"></label>
                             <div class="key-input-row">
                                 <input type="password" x-model="settings.apiKeys[key]"
+                                       @input="_debounceCheckProvider()"
+                                       @keydown.enter="checkProvider()"
                                        :placeholder="appSettings.apiKeysSet[key] ? '(set in .env)' : '(not set)'">
                                 <span class="key-status"
                                       :class="(settings.apiKeys[key] || appSettings.apiKeysSet[key]) ? 'key-set' : 'key-unset'"
-                                      x-text="(settings.apiKeys[key] || appSettings.apiKeysSet[key]) ? 'SET' : '-'"></span>
+                                      x-text="(settings.apiKeys[key] || appSettings.apiKeysSet[key]) ? '✓' : ''"></span>
+                                <button class="btn btn-ghost btn-sm" style="padding:2px 5px;font-size:0.8rem;flex-shrink:0"
+                                        @click="checkProvider()" :disabled="providerRuntime().checking" title="Check connection">↻</button>
                             </div>
                         </div>
                     </template>

--- a/src/hr_breaker/static/js/app.js
+++ b/src/hr_breaker/static/js/app.js
@@ -78,6 +78,8 @@ document.addEventListener('alpine:init', () => {
             list: [],
             selected: null,
             documents: [],
+            selectedDocIds: [],
+            selectionCustomized: false,
             loading: false,
             uploading: false,
             synthesizing: false,
@@ -1290,6 +1292,8 @@ document.addEventListener('alpine:init', () => {
         async openProfileEditor(p) {
             this.profile.selected = p;
             this.profile.documents = [];
+            this.profile.selectedDocIds = [];
+            this.profile.selectionCustomized = false;
             this.profile.extractionLogs = [];
             this.profile.error = null;
             await this._refreshProfileDocs(p.id);
@@ -1300,10 +1304,37 @@ document.addEventListener('alpine:init', () => {
             this._stopExtractionPoll();
             this.profile.selected = null;
             this.profile.documents = [];
+            this.profile.selectedDocIds = [];
+            this.profile.selectionCustomized = false;
             this.profile.extractionLogs = [];
             this.profile.showNoteForm = false;
             this.profile.error = null;
         },
+
+        _defaultSelectedProfileDocIds(documents = this.profile.documents) {
+            const preferred = (documents || []).filter((doc) => doc.included_by_default).map((doc) => doc.id);
+            if (preferred.length) return preferred;
+            return (documents || []).map((doc) => doc.id);
+        },
+
+        selectedProfileDocumentCount() {
+            return (this.profile.selectedDocIds || []).length;
+        },
+
+        isProfileDocSelected(docId) {
+            return (this.profile.selectedDocIds || []).includes(docId);
+        },
+
+        setProfileDocSelected(docId, selected) {
+            const current = new Set(this.profile.selectedDocIds || []);
+            if (selected) current.add(docId);
+            else current.delete(docId);
+            this.profile.selectedDocIds = this.profile.documents
+                .map((doc) => doc.id)
+                .filter((id) => current.has(id));
+            this.profile.selectionCustomized = true;
+        },
+
 
         _updateProfileSummary(pid, updates) {
             this.profile.list = this.profile.list.map((profile) => profile.id === pid ? { ...profile, ...updates } : profile);
@@ -1317,10 +1348,17 @@ document.addEventListener('alpine:init', () => {
                 const resp = await fetch('/api/profile/' + pid);
                 if (!resp.ok) return;
                 const data = await resp.json();
-                this.profile.documents = data.documents || [];
+                const documents = data.documents || [];
+                this.profile.documents = documents;
+                if (this.profile.selectionCustomized) {
+                    const currentIds = new Set(documents.map((doc) => doc.id));
+                    this.profile.selectedDocIds = (this.profile.selectedDocIds || []).filter((id) => currentIds.has(id));
+                } else {
+                    this.profile.selectedDocIds = this._defaultSelectedProfileDocIds(documents);
+                }
                 this._updateProfileSummary(pid, {
                     display_name: data.name || this.profile.selected?.display_name,
-                    document_count: (data.documents || []).length,
+                    document_count: documents.length,
                 });
             } catch (e) {
                 console.error('Failed to load profile docs:', e);
@@ -1405,6 +1443,7 @@ document.addEventListener('alpine:init', () => {
             if (!this.profile.selected) return;
             await fetch('/api/profile/' + this.profile.selected.id + '/document/' + docId, { method: 'DELETE' });
             this.profile.documents = this.profile.documents.filter(d => d.id !== docId);
+            this.profile.selectedDocIds = (this.profile.selectedDocIds || []).filter((id) => id !== docId);
             this._updateProfileSummary(this.profile.selected.id, { document_count: this.profile.documents.length });
         },
 
@@ -1460,6 +1499,7 @@ document.addEventListener('alpine:init', () => {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     job_text: this.job.text || null,
+                    selected_doc_ids: this.profile.selectedDocIds || [],
                     ...this._profileRunOverrides(),
                 }),
             });

--- a/src/hr_breaker/static/js/app.js
+++ b/src/hr_breaker/static/js/app.js
@@ -8,7 +8,7 @@ document.addEventListener('alpine:init', () => {
             lastName: null,
             contentPreview: '',
             instructions: '',
-            inputMode: 'upload', // 'upload' | 'paste'
+            inputMode: 'upload', // 'upload' | 'paste' | 'profile'
             pasteText: '',
             loading: false,
             showPreview: false,
@@ -41,6 +41,7 @@ document.addEventListener('alpine:init', () => {
             flashModel: '',
             embeddingModel: '',
             reasoningEffort: '',
+            showIntermediateLogs: false,
             apiKeys: { gemini: '', openrouter: '', openai: '', anthropic: '', moonshot: '' },
             thresholds: { hallucination: 0.9, keyword: 0.25, llm: 0.7, vector: 0.4, ai_generated: 0.4, translation: 0.95 },
         },
@@ -65,9 +66,46 @@ document.addEventListener('alpine:init', () => {
             iterations: [],
             logs: [],
             logsOpen: false,
+            usageEntries: [],
+            usageTotals: { requests: 0, input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_write_tokens: 0 },
             finalResult: null,
             error: null,
             cancelled: false,
+        },
+
+        // Profile state
+        profile: {
+            list: [],
+            selected: null,
+            documents: [],
+            loading: false,
+            uploading: false,
+            synthesizing: false,
+            activatingId: null,
+            creating: false,
+            newName: '',
+            newInstructions: '',
+            extractionLogs: [],
+            logsOpen: false,
+            error: null,
+            uploadProgress: null,
+            showNoteForm: false,
+            noteTitle: '',
+            noteContent: '',
+            addingNote: false,
+            _pollTimer: null,
+
+        },
+
+        // Provider state
+        provider: {
+            activeScope: 'pro',
+            shared: { selected: 'gemini', baseUrl: '' },
+            scopes: {
+                pro: { selected: null, baseUrl: null, status: 'unknown', message: '', detail: '', chatModels: [], embeddingModels: [], checking: false, _debounceTimer: null, _requestId: 0 },
+                flash: { selected: null, baseUrl: null, status: 'unknown', message: '', detail: '', chatModels: [], embeddingModels: [], checking: false, _debounceTimer: null, _requestId: 0 },
+                embedding: { selected: null, baseUrl: null, status: 'unknown', message: '', detail: '', chatModels: [], embeddingModels: [], checking: false, _debounceTimer: null, _requestId: 0 },
+            },
         },
 
         // Cached resumes/jobs for pickers
@@ -107,11 +145,66 @@ document.addEventListener('alpine:init', () => {
             ];
         },
 
+        get resumePickerEntries() {
+            const profileNames = new Set(
+                this.profile.list
+                    .map((p) => (p.display_name || p.id).trim())
+                    .filter(Boolean)
+            );
+            const resumeEntries = this.cachedResumes.map((r) => {
+                const resumeName = [r.first_name, r.last_name].filter(Boolean).join(' ') || 'Unknown';
+                const inferredProfileName = !r.source_type && (r.filename || 'pasted') === 'pasted' && profileNames.has(resumeName)
+                    ? resumeName
+                    : null;
+                return {
+                    key: `resume:${r.checksum}`,
+                    kind: 'resume',
+                    name: resumeName,
+                    meta: r.source_type === 'profile' || inferredProfileName
+                        ? `from profile: ${r.source_profile_name || inferredProfileName || resumeName || 'unknown'}`
+                        : (r.filename || 'pasted'),
+                    timestamp: r.timestamp,
+                    resume: r,
+                };
+            });
+            const hiddenProfileIds = new Set(
+                this.cachedResumes
+                    .filter((r) => r.source_type === 'profile')
+                    .map((r) => r.source_profile_id)
+                    .filter(Boolean)
+            );
+            const hiddenProfileNames = new Set(
+                this.cachedResumes
+                    .map((r) => {
+                        const resumeName = [r.first_name, r.last_name].filter(Boolean).join(' ').trim();
+                        if (r.source_type === 'profile') {
+                            return (r.source_profile_name || resumeName).trim();
+                        }
+                        return (r.filename || 'pasted') === 'pasted' && profileNames.has(resumeName) ? resumeName : null;
+                    })
+                    .filter(Boolean)
+            );
+            const profileEntries = this.profile.list
+                .filter((p) => (p.document_count || 0) > 0)
+                .filter((p) => !hiddenProfileIds.has(p.id))
+                .filter((p) => !hiddenProfileNames.has((p.display_name || p.id).trim()))
+                .map((p) => ({
+                    key: `profile:${p.id}`,
+                    kind: 'profile',
+                    name: p.display_name || p.id,
+                    meta: `profile · ${p.document_count || 0} document(s)`,
+                    timestamp: null,
+                    profile: p,
+                }));
+            return [...resumeEntries, ...profileEntries];
+        },
+
         async init() {
             this._restoreFromStorage();
             await Promise.all([
                 this.loadSettings(),
                 this.loadCachedResumes(),
+                this.loadProfiles(),
                 this.loadCachedJobs(),
                 this.loadHistory(),
                 this.checkActiveOptimization(),
@@ -123,14 +216,17 @@ document.addEventListener('alpine:init', () => {
             // Watch for changes and persist
             this.$watch('settings', () => this._saveToStorage());
 
+            // Load provider catalogs after settings, so env keys are known
+            await this.checkAllProviders();
         },
 
         _storageKey: 'hr-breaker-state',
 
         _saveToStorage() {
             const state = {
-                settings: { ...this.settings, apiKeys: undefined },
+                settings: this.settings,
                 drawerSections: this.drawerSections,
+                provider: this._providerPreferences(),
             };
             try { localStorage.setItem(this._storageKey, JSON.stringify(state)); } catch {}
         },
@@ -143,14 +239,21 @@ document.addEventListener('alpine:init', () => {
                 if (!raw) return;
                 const state = JSON.parse(raw);
                 if (state.settings) {
-                    const { apiKeys, ...rest } = state.settings;
-                    Object.assign(this.settings, rest);
-                    // Always reset apiKeys to empty (never restore from storage)
-                    this.settings.apiKeys = { gemini: '', openrouter: '', openai: '', anthropic: '', moonshot: '' };
+                    Object.assign(this.settings, state.settings);
                     this._restoredFromStorage = true;
                 }
                 if (state.drawerSections) {
                     Object.assign(this.drawerSections, state.drawerSections);
+                }
+                if (state.provider && typeof state.provider === 'object') {
+                    this._applyProviderPreferences(state.provider);
+                } else {
+                    this._applyProviderPreferences({
+                        shared: {
+                            selected: state.providerSelected,
+                            customBaseUrl: state.providerBaseUrl,
+                        },
+                    });
                 }
             } catch {}
         },
@@ -233,6 +336,14 @@ document.addEventListener('alpine:init', () => {
             await fetch('/api/resume/select/' + r.checksum, { method: 'POST' });
         },
 
+        async selectResumeSource(entry) {
+            if (entry.kind === 'profile') {
+                await this.selectProfile(entry.profile);
+                return;
+            }
+            await this.selectCachedResume(entry.resume);
+        },
+
         async loadResumeContent() {
             if (this.resume.contentPreview || !this.resume.checksum) return;
             try {
@@ -270,6 +381,22 @@ document.addEventListener('alpine:init', () => {
 
         // --- Resume actions ---
 
+        _resumeRunOverrides() {
+            return {
+                flash_model: this.settings.flashModel || null,
+                reasoning_effort: this.settings.reasoningEffort || null,
+                api_keys: this._nonEmptyApiKeys() || null,
+                providers: this._providerOverridesForRequest(['flash']),
+            };
+        },
+
+        _appendRunOverridesToFormData(formData, overrides) {
+            if (overrides.flash_model) formData.append('flash_model', overrides.flash_model);
+            if (overrides.reasoning_effort) formData.append('reasoning_effort', overrides.reasoning_effort);
+            if (overrides.api_keys) formData.append('api_keys_json', JSON.stringify(overrides.api_keys));
+            if (overrides.providers) formData.append('providers_json', JSON.stringify(overrides.providers));
+        },
+
         async handleFileUpload(event) {
             const file = event.target.files[0];
             if (!file) return;
@@ -279,6 +406,7 @@ document.addEventListener('alpine:init', () => {
             try {
                 const formData = new FormData();
                 formData.append('file', file);
+                this._appendRunOverridesToFormData(formData, this._resumeRunOverrides());
                 const resp = await fetch('/api/resume/upload', { method: 'POST', body: formData });
                 if (!resp.ok) {
                     const text = await resp.text();
@@ -311,7 +439,10 @@ document.addEventListener('alpine:init', () => {
                 const resp = await fetch('/api/resume/paste', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ content: this.resume.pasteText }),
+                    body: JSON.stringify({
+                        content: this.resume.pasteText,
+                        ...this._resumeRunOverrides(),
+                    }),
                 });
                 if (!resp.ok) {
                     const text = await resp.text();
@@ -443,6 +574,8 @@ document.addEventListener('alpine:init', () => {
             this.optimization.iterations = [];
             this.optimization.logs = [];
             this.optimization.logsOpen = false;
+            this.optimization.usageEntries = [];
+            this.optimization.usageTotals = { requests: 0, input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_write_tokens: 0 };
             this.optimization.error = null;
             this.optimization.cancelled = false;
             this.optimization.statusMessage = '';
@@ -501,6 +634,8 @@ document.addEventListener('alpine:init', () => {
             this.optimization.iterations = [];
             this.optimization.logs = [];
             this.optimization.logsOpen = false;
+            this.optimization.usageEntries = [];
+            this.optimization.usageTotals = { requests: 0, input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_write_tokens: 0 };
             this.optimization.finalResult = null;
             this.optimization.error = null;
             this.optimization.cancelled = false;
@@ -525,6 +660,7 @@ document.addEventListener('alpine:init', () => {
                 embedding_model: this.settings.embeddingModel || null,
                 reasoning_effort: this.settings.reasoningEffort || null,
                 api_keys: this._nonEmptyApiKeys() || null,
+                providers: this._providerOverridesForRequest(),
                 filter_thresholds: this.settings.thresholds,
             };
 
@@ -638,8 +774,24 @@ document.addEventListener('alpine:init', () => {
                     this.optimization.running = false;
                     break;
                 case 'log':
-                    this.optimization.logs.push(data);
-                    // Cap at 200 entries
+                    this.optimization.logs.push({ ...data, kind: 'log' });
+                    if (this.optimization.logs.length > 200) {
+                        this.optimization.logs.splice(0, this.optimization.logs.length - 200);
+                    }
+                    this._scrollLogPanel();
+                    break;
+                case 'usage':
+                    this.optimization.usageTotals = data.totals || this.optimization.usageTotals;
+                    this.optimization.usageEntries.push(data.entry);
+                    if (this.optimization.usageEntries.length > 200) {
+                        this.optimization.usageEntries.splice(0, this.optimization.usageEntries.length - 200);
+                    }
+                    this.optimization.logs.push({
+                        kind: 'usage',
+                        level: data.entry.usage_available === false ? 'WARNING' : 'INFO',
+                        message: this.formatUsageEntry(data.entry),
+                        usage_available: data.entry.usage_available,
+                    });
                     if (this.optimization.logs.length > 200) {
                         this.optimization.logs.splice(0, this.optimization.logs.length - 200);
                     }
@@ -663,6 +815,71 @@ document.addEventListener('alpine:init', () => {
             this.expandedIterations[idx] = !this.expandedIterations[idx];
         },
 
+        formatCount(value) {
+            return Number(value || 0).toLocaleString();
+        },
+
+        visibleOptimizationLogs() {
+            return this.optimization.logs.filter(log => log.kind !== 'usage' || this.settings.showIntermediateLogs || log.usage_available === false);
+        },
+
+        usageStatusLines() {
+            const summaries = this.usageSummariesByModel();
+            if (summaries.length === 0) {
+                if (this.optimization.usageTotals.requests === 0
+                    && this.optimization.usageTotals.input_tokens === 0
+                    && this.optimization.usageTotals.output_tokens === 0
+                    && this.optimization.usageTotals.cache_read_tokens === 0
+                    && this.optimization.usageTotals.cache_write_tokens === 0) {
+                    return [];
+                }
+                return [this.formatUsageSummary({ label: 'Total', ...this.optimization.usageTotals })];
+            }
+            if (summaries.length === 1) {
+                return [this.formatUsageSummary(summaries[0])];
+            }
+            return [
+                this.formatUsageSummary({ label: 'Total', ...this.optimization.usageTotals }),
+                ...summaries.map(summary => this.formatUsageSummary(summary)),
+            ];
+        },
+
+        usageSummariesByModel() {
+            const grouped = new Map();
+            for (const entry of this.optimization.usageEntries) {
+                if (entry.usage_available === false) continue;
+                const key = `${entry.model}|||${entry.provider}`;
+                if (!grouped.has(key)) {
+                    grouped.set(key, {
+                        label: `${entry.model} / ${entry.provider}`,
+                        requests: 0,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        cache_read_tokens: 0,
+                        cache_write_tokens: 0,
+                    });
+                }
+                const summary = grouped.get(key);
+                summary.requests += Number(entry.requests || 0);
+                summary.input_tokens += Number(entry.input_tokens || 0);
+                summary.output_tokens += Number(entry.output_tokens || 0);
+                summary.cache_read_tokens += Number(entry.cache_read_tokens || 0);
+                summary.cache_write_tokens += Number(entry.cache_write_tokens || 0);
+            }
+            return [...grouped.values()];
+        },
+
+        formatUsageSummary(summary) {
+            return `${summary.label}: Requests ${this.formatCount(summary.requests)} | Cache ${this.formatCount(summary.cache_read_tokens)}r / ${this.formatCount(summary.cache_write_tokens)}w | Input ${this.formatCount(summary.input_tokens)} | Output ${this.formatCount(summary.output_tokens)}`;
+        },
+
+        formatUsageEntry(entry) {
+            if (entry.usage_available === false) {
+                return `${entry.timestamp} ${entry.component}: ${entry.model} / ${entry.provider}, usage unavailable`;
+            }
+            return `${entry.timestamp} ${entry.component}: ${entry.model} / ${entry.provider}, requests: ${this.formatCount(entry.requests)}, cache: ${this.formatCount(entry.cache_read_tokens)}r / ${this.formatCount(entry.cache_write_tokens)}w, input: ${this.formatCount(entry.input_tokens)}, output: ${this.formatCount(entry.output_tokens)}`;
+        },
+
         // --- Helpers ---
 
         _nonEmptyApiKeys() {
@@ -672,6 +889,17 @@ document.addEventListener('alpine:init', () => {
                 if (v) { keys[k] = v; hasAny = true; }
             }
             return hasAny ? keys : null;
+        },
+
+        _profileRunOverrides() {
+            const overrides = {
+                flash_model: this.settings.flashModel || null,
+                embedding_model: this.settings.embeddingModel || null,
+                reasoning_effort: this.settings.reasoningEffort || null,
+                api_keys: this._nonEmptyApiKeys() || null,
+                providers: this._providerOverridesForRequest(['flash', 'embedding']),
+            };
+            return overrides;
         },
 
         // --- History ---
@@ -698,6 +926,569 @@ document.addEventListener('alpine:init', () => {
                 const path = u.pathname.length > 30 ? u.pathname.substring(0, 30) + '...' : u.pathname;
                 return u.hostname + path;
             } catch { return url.substring(0, 40); }
+        },
+
+        // --- Provider actions ---
+
+        providerScopes() {
+            return ['pro', 'flash', 'embedding'];
+        },
+
+        providerTabLabel(scope) {
+            return { pro: 'Pro', flash: 'Flash', embedding: 'Embedding' }[scope] || scope;
+        },
+
+        providerRuntime(scope = this.provider.activeScope) {
+            return this.provider.scopes[scope];
+        },
+
+        providerSelected(scope = this.provider.activeScope) {
+            return this._providerEffectivePreferences(scope).selected;
+        },
+
+        providerBaseUrl(scope = this.provider.activeScope) {
+            return this._providerEffectivePreferences(scope).customBaseUrl;
+        },
+
+        providerUsesShared(scope = this.provider.activeScope) {
+            return scope !== 'pro' && this.providerRuntime(scope).selected == null && this.providerRuntime(scope).baseUrl == null;
+        },
+
+        providerScopeSummary(scope = this.provider.activeScope) {
+            if (scope === 'pro') {
+                return 'Pro is the shared provider default for Flash and Embedding unless overridden.';
+            }
+            return this.providerUsesShared(scope)
+                ? `Using Pro provider by default for ${this.providerTabLabel(scope)}.`
+                : `Using a separate provider for ${this.providerTabLabel(scope)}.`;
+        },
+
+        canResetProviderOverride(scope = this.provider.activeScope) {
+            return scope !== 'pro' && !this.providerUsesShared(scope);
+        },
+
+        providerChatModels(scope) {
+            return this.providerRuntime(scope).chatModels || [];
+        },
+
+        providerEmbeddingModels(scope) {
+            return this.providerRuntime(scope).embeddingModels || [];
+        },
+
+        _providerPreferences() {
+            return {
+                activeScope: this.provider.activeScope || 'pro',
+                shared: {
+                    selected: this.provider.shared.selected || 'gemini',
+                    customBaseUrl: (this.provider.shared.baseUrl || '').trim(),
+                },
+                overrides: {
+                    flash: this._providerOverridePreferences('flash'),
+                    embedding: this._providerOverridePreferences('embedding'),
+                },
+            };
+        },
+
+        _providerOverridePreferences(scope) {
+            if (scope === 'pro') return null;
+            const state = this.providerRuntime(scope);
+            if (state.selected == null && state.baseUrl == null) return null;
+            return {
+                selected: state.selected || null,
+                customBaseUrl: (state.baseUrl || '').trim(),
+            };
+        },
+
+        _applyProviderPreferences(preferences) {
+            if (!preferences || typeof preferences !== 'object') return;
+            const shared = preferences.shared && typeof preferences.shared === 'object' ? preferences.shared : preferences;
+            this.provider.activeScope = preferences.activeScope || 'pro';
+            this.provider.shared.selected = shared.selected || 'gemini';
+            this.provider.shared.baseUrl = String(shared.customBaseUrl || '');
+
+            for (const scope of ['flash', 'embedding']) {
+                const state = this.providerRuntime(scope);
+                state.selected = null;
+                state.baseUrl = null;
+                const override = preferences.overrides && typeof preferences.overrides === 'object' ? preferences.overrides[scope] : null;
+                if (override && typeof override === 'object') {
+                    state.selected = override.selected || null;
+                    state.baseUrl = override.customBaseUrl != null ? String(override.customBaseUrl) : null;
+                    this._collapseProviderOverride(scope);
+                }
+            }
+        },
+
+        _providerEffectivePreferences(scope = this.provider.activeScope) {
+            if (scope === 'pro') {
+                return {
+                    selected: this.provider.shared.selected || 'gemini',
+                    customBaseUrl: (this.provider.shared.baseUrl || '').trim(),
+                };
+            }
+            const state = this.providerRuntime(scope);
+            return {
+                selected: state.selected || this.provider.shared.selected || 'gemini',
+                customBaseUrl: ((state.baseUrl != null ? state.baseUrl : this.provider.shared.baseUrl) || '').trim(),
+            };
+        },
+
+        _matchingProviderScopes(scope = this.provider.activeScope) {
+            const prefs = this._providerEffectivePreferences(scope);
+            return this.providerScopes().filter(candidate => {
+                const other = this._providerEffectivePreferences(candidate);
+                return other.selected === prefs.selected && other.customBaseUrl === prefs.customBaseUrl;
+            });
+        },
+
+        _collapseProviderOverride(scope) {
+            if (scope === 'pro') return;
+            const state = this.providerRuntime(scope);
+            const sharedSelected = this.provider.shared.selected || 'gemini';
+            const sharedBaseUrl = (this.provider.shared.baseUrl || '').trim();
+            const selected = state.selected || sharedSelected;
+            const baseUrl = (state.baseUrl || '').trim();
+            if (selected === sharedSelected && baseUrl === sharedBaseUrl) {
+                state.selected = null;
+                state.baseUrl = null;
+            }
+        },
+
+        _resetProviderStatus(scope = this.provider.activeScope, message = '') {
+            for (const candidate of this._matchingProviderScopes(scope)) {
+                const state = this.providerRuntime(candidate);
+                state._requestId = (state._requestId || 0) + 1;
+                state.status = 'unknown';
+                state.message = message;
+                state.detail = '';
+                state.chatModels = [];
+                state.embeddingModels = [];
+                state.checking = false;
+            }
+        },
+
+        _providerKeyName(scope = this.provider.activeScope) {
+            const providerName = this.providerSelected(scope);
+            return providerName === 'custom' ? 'openai' : (providerName || 'gemini');
+        },
+
+        _providerApiKey(scope = this.provider.activeScope) {
+            return this.settings.apiKeys[this._providerKeyName(scope)] || '';
+        },
+
+        _providerHasEnvKey(scope = this.provider.activeScope) {
+            return this.appSettings.apiKeysSet[this._providerKeyName(scope)] || false;
+        },
+
+        _providerCheckRequest(scope = this.provider.activeScope) {
+            const preferences = this._providerEffectivePreferences(scope);
+            const body = {
+                provider: preferences.selected,
+                api_key: this._providerApiKey(scope) || null,
+            };
+            if (preferences.selected === 'custom' && preferences.customBaseUrl) {
+                body.base_url = preferences.customBaseUrl;
+            }
+            return body;
+        },
+
+        _providerOverridesForRequest(scopes = this.providerScopes()) {
+            const providers = {};
+            for (const scope of scopes) {
+                const preferences = this._providerEffectivePreferences(scope);
+                providers[scope] = {
+                    provider: preferences.selected || null,
+                    base_url: preferences.selected === 'custom' ? (preferences.customBaseUrl || null) : null,
+                };
+            }
+            return providers;
+        },
+
+        setProviderScope(scope) {
+            this.provider.activeScope = scope;
+            this._saveToStorage();
+            const state = this.providerRuntime(scope);
+            if (!state.chatModels.length && !state.embeddingModels.length) {
+                this.checkProvider(scope);
+            }
+        },
+
+        resetProviderOverride(scope = this.provider.activeScope) {
+            if (scope === 'pro') return;
+            const state = this.providerRuntime(scope);
+            state.selected = null;
+            state.baseUrl = null;
+            this._saveToStorage();
+            this._resetProviderStatus(scope);
+            this.checkProvider(scope);
+        },
+
+        handleProviderSelectionChange(value, scope = this.provider.activeScope) {
+            if (scope === 'pro') {
+                this.provider.shared.selected = value || 'gemini';
+                if (this.provider.shared.selected !== 'custom') {
+                    this.provider.shared.baseUrl = '';
+                }
+            } else {
+                const state = this.providerRuntime(scope);
+                state.selected = value || 'gemini';
+                if (state.selected !== 'custom') {
+                    state.baseUrl = '';
+                }
+                this._collapseProviderOverride(scope);
+            }
+            this._saveToStorage();
+            this._resetProviderStatus(scope);
+            this.checkProvider(scope);
+        },
+
+        handleProviderBaseUrlInput(value, scope = this.provider.activeScope) {
+            if (scope === 'pro') {
+                this.provider.shared.baseUrl = String(value || '');
+            } else {
+                const state = this.providerRuntime(scope);
+                state.selected = state.selected || this.provider.shared.selected || 'gemini';
+                state.baseUrl = String(value || '');
+                this._collapseProviderOverride(scope);
+            }
+            this._saveToStorage();
+            this._resetProviderStatus(scope);
+            this._debounceCheckProvider(scope);
+        },
+
+        _debounceCheckProvider(scope = this.provider.activeScope) {
+            const state = this.providerRuntime(scope);
+            if (state._debounceTimer) clearTimeout(state._debounceTimer);
+            state._debounceTimer = setTimeout(() => this.checkProvider(scope), 500);
+        },
+
+        async checkAllProviders() {
+            for (const scope of this.providerScopes()) {
+                await this.checkProvider(scope);
+            }
+        },
+
+        async checkProvider(scope = this.provider.activeScope) {
+            const requestBody = this._providerCheckRequest(scope);
+            const hasEnvKey = this._providerHasEnvKey(scope);
+            const matchingScopes = this._matchingProviderScopes(scope);
+
+            if (!requestBody.api_key && !hasEnvKey) {
+                this._resetProviderStatus(scope, 'Enter API key to load models');
+                return;
+            }
+
+            const requestId = (this.providerRuntime(scope)._requestId || 0) + 1;
+            for (const candidate of matchingScopes) {
+                const state = this.providerRuntime(candidate);
+                state._requestId = requestId;
+                state.checking = true;
+            }
+
+            try {
+                const resp = await fetch('/api/providers/check', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                });
+                const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(data.detail || data.error || data.message || 'Request failed');
+                }
+                for (const candidate of matchingScopes) {
+                    const state = this.providerRuntime(candidate);
+                    if (state._requestId !== requestId) continue;
+                    state.status = data.status.state;
+                    state.message = data.status.message;
+                    state.detail = data.status.detail || '';
+                    state.chatModels = data.chat_models || [];
+                    state.embeddingModels = data.embedding_models || [];
+                }
+            } catch (e) {
+                for (const candidate of matchingScopes) {
+                    const state = this.providerRuntime(candidate);
+                    if (state._requestId !== requestId) continue;
+                    state.status = 'warning';
+                    state.message = 'Check failed';
+                    state.detail = e instanceof Error ? e.message : String(e);
+                    state.chatModels = [];
+                    state.embeddingModels = [];
+                }
+            } finally {
+                for (const candidate of matchingScopes) {
+                    const state = this.providerRuntime(candidate);
+                    if (state._requestId === requestId) state.checking = false;
+                }
+            }
+        },
+
+        // --- Profile actions ---
+
+        async loadProfiles() {
+            this.profile.loading = true;
+            try {
+                const resp = await fetch('/api/profile/');
+                this.profile.list = await resp.json();
+            } catch (e) {
+                console.error('Failed to load profiles:', e);
+            } finally {
+                this.profile.loading = false;
+            }
+        },
+
+        async createProfile() {
+            if (!this.profile.newName.trim()) return;
+            this.profile.loading = true;
+            try {
+                const resp = await fetch('/api/profile/', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name: this.profile.newName.trim(),
+                        instructions: this.profile.newInstructions.trim() || null,
+                    }),
+                });
+                if (!resp.ok) throw new Error(await resp.text());
+                const p = await resp.json();
+                this.profile.list.unshift({ ...p, document_count: 0, created_at: null });
+                this.profile.creating = false;
+                this.profile.newName = '';
+                this.profile.newInstructions = '';
+            } catch (e) {
+                console.error('Failed to create profile:', e);
+            } finally {
+                this.profile.loading = false;
+            }
+        },
+
+        async deleteProfile(pid) {
+            if (!confirm('Delete this profile and all its documents?')) return;
+            await fetch('/api/profile/' + pid, { method: 'DELETE' });
+            this.profile.list = this.profile.list.filter(p => p.id !== pid);
+            if (this.profile.selected && this.profile.selected.id === pid) {
+                this.closeProfileEditor();
+            }
+        },
+
+        async selectProfile(p) {
+            if ((p.document_count || 0) === 0) {
+                await this.openProfileEditor(p);
+                return;
+            }
+            this.profile.activatingId = p.id;
+            this.resume.error = null;
+            this.profile.error = null;
+            try {
+                await this._synthesizeProfileToResume(p.id);
+            } catch (e) {
+                this.resume.error = 'Profile selection failed: ' + e.message;
+            } finally {
+                this.profile.activatingId = null;
+            }
+        },
+
+        async openProfileEditor(p) {
+            this.profile.selected = p;
+            this.profile.documents = [];
+            this.profile.extractionLogs = [];
+            this.profile.error = null;
+            await this._refreshProfileDocs(p.id);
+            this._startExtractionPoll(p.id);
+        },
+
+        closeProfileEditor() {
+            this._stopExtractionPoll();
+            this.profile.selected = null;
+            this.profile.documents = [];
+            this.profile.extractionLogs = [];
+            this.profile.showNoteForm = false;
+            this.profile.error = null;
+        },
+
+        _updateProfileSummary(pid, updates) {
+            this.profile.list = this.profile.list.map((profile) => profile.id === pid ? { ...profile, ...updates } : profile);
+            if (this.profile.selected && this.profile.selected.id === pid) {
+                this.profile.selected = { ...this.profile.selected, ...updates };
+            }
+        },
+
+        async _refreshProfileDocs(pid) {
+            try {
+                const resp = await fetch('/api/profile/' + pid);
+                if (!resp.ok) return;
+                const data = await resp.json();
+                this.profile.documents = data.documents || [];
+                this._updateProfileSummary(pid, {
+                    display_name: data.name || this.profile.selected?.display_name,
+                    document_count: (data.documents || []).length,
+                });
+            } catch (e) {
+                console.error('Failed to load profile docs:', e);
+            }
+        },
+
+        _startExtractionPoll(pid) {
+            this._stopExtractionPoll();
+            const poll = async () => {
+                try {
+                    const resp = await fetch('/api/profile/' + pid + '/extraction-status');
+                    if (!resp.ok) return;
+                    const data = await resp.json();
+                    // Append new logs
+                    if (data.logs && data.logs.length > 0) {
+                        this.profile.extractionLogs.push(...data.logs);
+                        if (this.profile.extractionLogs.length > 200) {
+                            this.profile.extractionLogs.splice(0, this.profile.extractionLogs.length - 200);
+                        }
+                    }
+                    // Refresh docs to show updated extraction_status
+                    if (data.active) {
+                        await this._refreshProfileDocs(pid);
+                        this.profile._pollTimer = setTimeout(poll, 1500);
+                    } else {
+                        await this._refreshProfileDocs(pid);
+                    }
+                } catch (e) {
+                    // Stop polling on error
+                }
+            };
+            this.profile._pollTimer = setTimeout(poll, 800);
+        },
+
+        _stopExtractionPoll() {
+            if (this.profile._pollTimer) {
+                clearTimeout(this.profile._pollTimer);
+                this.profile._pollTimer = null;
+            }
+        },
+
+        async uploadProfileDoc(event) {
+            const fileList = event.target.files;
+            if (!fileList || !fileList.length || !this.profile.selected) return;
+            // Snapshot files before any DOM changes
+            const files = Array.from(fileList);
+            this.profile.uploading = true;
+            this.profile.error = null;
+            this.profile.uploadProgress = files.length > 1 ? `Uploading 1/${files.length}...` : 'Uploading...';
+            try {
+                const pid = this.profile.selected.id;
+                for (let i = 0; i < files.length; i++) {
+                    this.profile.uploadProgress = files.length > 1 ? `Uploading ${i + 1}/${files.length}...` : 'Uploading...';
+                    const formData = new FormData();
+                    formData.append('file', files[i]);
+                    this._appendRunOverridesToFormData(formData, this._profileRunOverrides());
+                    const resp = await fetch('/api/profile/' + pid + '/document', {
+                        method: 'POST',
+                        body: formData,
+                    });
+                    if (!resp.ok) {
+                        const text = await resp.text();
+                        try { const j = JSON.parse(text); throw new Error(j.error || j.detail || text); }
+                        catch (pe) { if (pe instanceof SyntaxError) throw new Error(text); throw pe; }
+                    }
+                }
+                await this._refreshProfileDocs(pid);
+                this._startExtractionPoll(pid);
+            } catch (e) {
+                this.profile.error = 'Upload failed: ' + e.message;
+            } finally {
+                this.profile.uploading = false;
+                this.profile.uploadProgress = null;
+                // Reset file input (if it's a real input element)
+                if (event.target && event.target.value !== undefined) {
+                    event.target.value = '';
+                }
+            }
+        },
+
+        async deleteProfileDoc(docId) {
+            if (!this.profile.selected) return;
+            await fetch('/api/profile/' + this.profile.selected.id + '/document/' + docId, { method: 'DELETE' });
+            this.profile.documents = this.profile.documents.filter(d => d.id !== docId);
+            this._updateProfileSummary(this.profile.selected.id, { document_count: this.profile.documents.length });
+        },
+
+        async reExtractProfile() {
+            if (!this.profile.selected) return;
+            this.profile.error = null;
+            try {
+                const pid = this.profile.selected.id;
+                const resp = await fetch('/api/profile/' + pid + '/extract', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(this._profileRunOverrides()),
+                });
+                const data = await resp.json();
+                if (!resp.ok) { this.profile.error = data.error || 'Re-extract failed'; return; }
+                await this._refreshProfileDocs(pid);
+                this._startExtractionPoll(pid);
+            } catch (e) {
+                this.profile.error = 'Re-extract failed: ' + e.message;
+            }
+        },
+
+        async addProfileNote() {
+            if (!this.profile.selected || !this.profile.noteTitle.trim()) return;
+            this.profile.addingNote = true;
+            this.profile.error = null;
+            try {
+                const resp = await fetch('/api/profile/' + this.profile.selected.id + '/note', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ title: this.profile.noteTitle.trim(), content: this.profile.noteContent.trim() }),
+                });
+                if (!resp.ok) {
+                    const text = await resp.text();
+                    try { const j = JSON.parse(text); throw new Error(j.detail || j.error || text); }
+                    catch (pe) { if (pe instanceof SyntaxError) throw new Error(text); throw pe; }
+                }
+                this.profile.noteTitle = '';
+                this.profile.noteContent = '';
+                this.profile.addingNote = false;
+                this.profile.showNoteForm = false;
+                await this._refreshProfileDocs(this.profile.selected.id);
+                this._startExtractionPoll(this.profile.selected.id);
+            } catch (e) {
+                this.profile.error = 'Failed to add note: ' + e.message;
+                this.profile.addingNote = false;
+            }
+        },
+
+        async _synthesizeProfileToResume(profileId) {
+            const resp = await fetch('/api/profile/' + profileId + '/synthesize', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    job_text: this.job.text || null,
+                    ...this._profileRunOverrides(),
+                }),
+            });
+            if (!resp.ok) {
+                const text = await resp.text();
+                try { const j = JSON.parse(text); throw new Error(j.detail || j.error || text); }
+                catch (pe) { if (pe instanceof SyntaxError) throw new Error(text); throw pe; }
+            }
+            const data = await resp.json();
+            this.resume.loaded = true;
+            this.resume.checksum = data.checksum;
+            this.resume.firstName = data.first_name || null;
+            this.resume.lastName = data.last_name || null;
+            this.resume.contentPreview = '';
+            this.resume.error = null;
+            await this.loadCachedResumes();
+        },
+
+        async synthesizeProfile() {
+            if (!this.profile.selected) return;
+            this.profile.synthesizing = true;
+            this.profile.error = null;
+            try {
+                await this._synthesizeProfileToResume(this.profile.selected.id);
+            } catch (e) {
+                this.profile.error = 'Synthesis failed: ' + e.message;
+            } finally {
+                this.profile.synthesizing = false;
+            }
         },
     }));
 });

--- a/src/hr_breaker/utils/optimization_telemetry.py
+++ b/src/hr_breaker/utils/optimization_telemetry.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Callable
+
+from hr_breaker.utils.retry import run_with_retry
+
+
+TelemetryReporter = Callable[[dict[str, Any]], None]
+
+
+_reporter: ContextVar[TelemetryReporter | None] = ContextVar("optimization_telemetry_reporter", default=None)
+
+
+@dataclass
+class UsageTotals:
+    requests: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+@contextmanager
+def telemetry_reporter(reporter: TelemetryReporter):
+    token = _reporter.set(reporter)
+    try:
+        yield
+    finally:
+        _reporter.reset(token)
+
+
+def provider_for_model(model_name: str) -> str:
+    return model_name.split("/", 1)[0] if "/" in model_name else "unknown"
+
+
+def _looks_like_embedding_model(model_name: str) -> bool:
+    return "embed" in model_name.lower()
+
+
+def zero_usage_totals() -> dict[str, int]:
+    return asdict(UsageTotals())
+
+
+def accumulate_usage_totals(totals: dict[str, int], usage_entry: dict[str, Any]) -> dict[str, int]:
+    updated = dict(totals)
+    if usage_entry.get("usage_available") is False:
+        return updated
+    for key in UsageTotals.__dataclass_fields__:
+        updated[key] = int(updated.get(key, 0)) + int(usage_entry.get(key, 0) or 0)
+    return updated
+
+
+def _usage_value(usage: Any, *names: str) -> int:
+    for name in names:
+        value = getattr(usage, name, None)
+        if value is not None:
+            return int(value or 0)
+    return 0
+
+
+def _usage_payload(component: str, model_name: str, usage: Any) -> dict[str, Any]:
+    input_tokens = _usage_value(usage, "input_tokens", "prompt_tokens")
+    output_tokens = _usage_value(usage, "output_tokens", "completion_tokens")
+    cache_read_tokens = _usage_value(usage, "cache_read_tokens")
+    cache_write_tokens = _usage_value(usage, "cache_write_tokens")
+    requests = _usage_value(usage, "requests") or (1 if any((input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)) else 0)
+    usage_available = any((input_tokens, output_tokens, cache_read_tokens, cache_write_tokens))
+    if not usage_available and _looks_like_embedding_model(model_name):
+        usage_available = False
+    else:
+        usage_available = True
+    return {
+        "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
+        "component": component,
+        "model": model_name,
+        "provider": provider_for_model(model_name),
+        "requests": requests,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_tokens": cache_read_tokens,
+        "cache_write_tokens": cache_write_tokens,
+        "usage_available": usage_available,
+    }
+
+
+def report_usage(component: str, model_name: str, usage: Any) -> None:
+    if usage is None:
+        return
+    reporter = _reporter.get()
+    if reporter is None:
+        return
+    reporter(_usage_payload(component, model_name, usage))
+
+
+async def run_tracked_agent(agent: Any, *args, component: str, **kwargs):
+    result = await run_with_retry(agent.run, *args, **kwargs)
+    model = getattr(agent, "model", None)
+    model_name = getattr(model, "model_name", "unknown")
+    usage_method = getattr(result, "usage", None)
+    usage = usage_method() if callable(usage_method) else usage_method
+    report_usage(component, model_name, usage)
+    return result

--- a/src/hr_breaker/utils/optimization_telemetry.py
+++ b/src/hr_breaker/utils/optimization_telemetry.py
@@ -69,10 +69,6 @@ def _usage_payload(component: str, model_name: str, usage: Any) -> dict[str, Any
     cache_write_tokens = _usage_value(usage, "cache_write_tokens")
     requests = _usage_value(usage, "requests") or (1 if any((input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)) else 0)
     usage_available = any((input_tokens, output_tokens, cache_read_tokens, cache_write_tokens))
-    if not usage_available and _looks_like_embedding_model(model_name):
-        usage_available = False
-    else:
-        usage_available = True
     return {
         "timestamp": datetime.now().strftime("%H:%M:%S.%f")[:-3],
         "component": component,

--- a/src/hr_breaker/utils/retry.py
+++ b/src/hr_breaker/utils/retry.py
@@ -19,8 +19,21 @@ logger = logging.getLogger(__name__)
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
+def _is_non_retryable_litellm_config_error(exc: BaseException) -> bool:
+    if not isinstance(exc, ModelHTTPError):
+        return False
+    message = str(exc)
+    return (
+        exc.status_code == 500
+        and "APIConnectionError" in message
+        and "argument of type 'NoneType' is not iterable" in message
+    )
+
+
 def is_retryable(exc: BaseException) -> bool:
     """Check if exception is retryable (rate limit or transient server error)."""
+    if _is_non_retryable_litellm_config_error(exc):
+        return False
     if isinstance(exc, ModelHTTPError):
         return exc.status_code in RETRYABLE_STATUS_CODES
     status = getattr(exc, "status_code", None)

--- a/templates/resume_guide.md
+++ b/templates/resume_guide.md
@@ -15,12 +15,14 @@ These classes are pre-defined and styled. Use them exactly as shown:
         <span class="sep">|</span>
         <span>555-123-4567</span>
         <span class="sep">|</span>
-        <a href="https://linkedin.com/in/username">LinkedIn</a>
+        <a href="https://linkedin.com/in/username">linkedin.com/in/username</a>
         <span class="sep">|</span>
-        <a href="https://github.com/username">GitHub</a>
+        <a href="https://github.com/username">github.com/username</a>
     </div>
 </header>
 ```
+
+The contact line automatically wraps to a second line if there are many items — no extra CSS needed.
 
 ### Sections
 ```html
@@ -97,9 +99,11 @@ Use `<strong>` for category labels (NOT markdown `**bold**`):
 ```html
 <ul class="simple-list">
     <li>AWS Certified Solutions Architect, 2023</li>
-    <li>Google Cloud Professional Data Engineer, 2022</li>
+    <li>Doe J. et al., "Title of Paper", Nature 2022 (DOI: 10.1000/xyz123)</li>
 </ul>
 ```
+
+For publications: include DOI in parentheses at the end if available.
 
 ## Visual Criteria
 

--- a/templates/resume_wrapper.html
+++ b/templates/resume_wrapper.html
@@ -43,6 +43,10 @@
 
         .contact-line {
             font-size: 10pt;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 0;
         }
 
         .contact-line .sep {
@@ -166,6 +170,7 @@
     </style>
 </head>
 <body>
+{{HEADER}}
 {{BODY}}
 </body>
 </html>

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -64,3 +64,22 @@ class TestResumeCache:
 
             result = cache.get("nonexistent")
             assert result is None
+
+
+    def test_get_marks_legacy_profile_synthesis_entries(self, tmp_path):
+        """Legacy profile-synthesized pasted entries should be hidden as profile sources."""
+        with patch.object(ResumeCache, '__init__', lambda self: None):
+            cache = ResumeCache()
+            cache.cache_dir = tmp_path
+            legacy = {
+                "content": "Profile: Jane Doe\n\nSelected evidence...",
+                "first_name": "Jane",
+                "timestamp": "2026-03-14T12:00:00",
+            }
+            legacy_file = tmp_path / "legacy-profile.json"
+            legacy_file.write_text(json.dumps(legacy))
+
+            result = cache.get("legacy-profile")
+            assert result is not None
+            assert result.source_type == "profile"
+            assert result.source_profile_name == "Jane Doe"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from hr_breaker.cli import cli
+import hr_breaker.config as config_module
+from hr_breaker.models.profile import DocumentExtraction
+from hr_breaker.services.profile_store import ProfileStore
+
+
+def test_profile_show_reports_empty_extraction(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path / "profiles"))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        doc = store.add_note(profile.id, title="Resume", content_text="raw text")
+
+        with patch(
+            "hr_breaker.agents.extractor.extract_document",
+            new=AsyncMock(return_value=DocumentExtraction()),
+        ):
+            asyncio.run(store.extract_document_content(profile.id, doc.id))
+
+        result = CliRunner().invoke(cli, ["profile", "show", profile.id])
+
+        assert result.exit_code == 0
+        assert "empty extraction" in result.output
+        assert "[note, extracted]" not in result.output
+    finally:
+        config_module.clear_settings_cache()
+
+
+def test_backfill_reports_empty_extraction_separately(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path / "profiles"))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        store.add_note(profile.id, title="Resume", content_text="raw text")
+
+        with patch(
+            "hr_breaker.agents.extractor.extract_document",
+            new=AsyncMock(return_value=DocumentExtraction()),
+        ):
+            result = CliRunner().invoke(cli, ["backfill", "--profile", profile.id])
+
+        assert result.exit_code == 0
+        assert "Resume... empty" in result.output
+        assert "Done: 0 extracted, 1 empty, 0 failed, 1 total" in result.output
+    finally:
+        config_module.clear_settings_cache()

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -1,0 +1,26 @@
+import logging
+
+import hr_breaker.config as config_module
+
+
+def test_setup_logging_uses_millisecond_precision(monkeypatch):
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    try:
+        monkeypatch.setenv("LOG_LEVEL_GENERAL", "INFO")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        config_module.setup_logging()
+
+        assert root.handlers, "Expected setup_logging() to install a handler"
+        formatter = root.handlers[0].formatter
+        assert formatter is not None
+        assert formatter._fmt == "%(asctime)s.%(msecs)03d [%(levelname)s] %(name)s - %(message)s"
+        assert formatter.datefmt == "%H:%M:%S"
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in original_handlers:
+            root.addHandler(handler)

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -1,4 +1,6 @@
 import os
+import threading
+import time
 
 import pytest
 
@@ -52,3 +54,42 @@ class TestSettingsOverride:
         original = config_module.get_settings().pro_model
         with config_module.settings_override({"pro_model": None}):
             assert config_module.get_settings().pro_model == original
+
+
+    def test_overrides_are_serialized_across_threads(self):
+        entered: list[str] = []
+        first_ready = threading.Event()
+        release_first = threading.Event()
+        second_done = threading.Event()
+        observed: dict[str, str] = {}
+
+        def first_worker():
+            with config_module.settings_override({"openai_api_base": "https://first.example.test/v1"}):
+                entered.append("first")
+                first_ready.set()
+                assert os.environ.get("OPENAI_API_BASE") == "https://first.example.test/v1"
+                assert release_first.wait(timeout=2)
+
+        def second_worker():
+            assert first_ready.wait(timeout=2)
+            with config_module.settings_override({"openai_api_base": "https://second.example.test/v1"}):
+                entered.append("second")
+                observed["value"] = os.environ.get("OPENAI_API_BASE") or ""
+            second_done.set()
+
+        first_thread = threading.Thread(target=first_worker)
+        second_thread = threading.Thread(target=second_worker)
+        first_thread.start()
+        second_thread.start()
+
+        assert first_ready.wait(timeout=2)
+        time.sleep(0.05)
+        assert entered == ["first"]
+
+        release_first.set()
+        first_thread.join(timeout=2)
+        second_thread.join(timeout=2)
+
+        assert second_done.is_set()
+        assert entered == ["first", "second"]
+        assert observed["value"] == "https://second.example.test/v1"

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -2,34 +2,53 @@ import os
 
 import pytest
 
-from hr_breaker.config import get_settings, settings_override
+import hr_breaker.config as config_module
 
 
 class TestSettingsOverride:
     def setup_method(self):
-        get_settings.cache_clear()
+        config_module.get_settings.cache_clear()
 
     def teardown_method(self):
-        get_settings.cache_clear()
+        config_module.get_settings.cache_clear()
 
     def test_override_restores_original(self):
-        original = get_settings().pro_model
-        with settings_override({"pro_model": "test/model-123"}):
-            assert get_settings().pro_model == "test/model-123"
-        assert get_settings().pro_model == original
+        original = config_module.get_settings().pro_model
+        with config_module.settings_override({"pro_model": "test/model-123"}):
+            assert config_module.get_settings().pro_model == "test/model-123"
+        assert config_module.get_settings().pro_model == original
 
     def test_override_api_key(self):
         original = os.environ.get("OPENAI_API_KEY")
-        with settings_override({"api_keys": {"openai": "sk-test-123"}}):
+        with config_module.settings_override({"api_keys": {"openai": "sk-test-123"}}):
             assert os.environ.get("OPENAI_API_KEY") == "sk-test-123"
         assert os.environ.get("OPENAI_API_KEY") == original
 
+    def test_override_openai_api_base(self):
+        original = os.environ.get("OPENAI_API_BASE")
+        with config_module.settings_override({"openai_api_base": "https://example.test/v1"}):
+            assert os.environ.get("OPENAI_API_BASE") == "https://example.test/v1"
+        assert os.environ.get("OPENAI_API_BASE") == original
+
+    def test_override_scoped_openai_api_bases(self):
+        original_flash = os.environ.get("FLASH_OPENAI_API_BASE")
+        original_embedding = os.environ.get("EMBEDDING_OPENAI_API_BASE")
+        with config_module.settings_override({
+            "flash_openai_api_base": "https://flash.example.test/v1",
+            "embedding_openai_api_base": "https://embed.example.test/v1",
+        }):
+            assert os.environ.get("FLASH_OPENAI_API_BASE") == "https://flash.example.test/v1"
+            assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == "https://embed.example.test/v1"
+        assert os.environ.get("FLASH_OPENAI_API_BASE") == original_flash
+        assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == original_embedding
+
+
     def test_empty_override_is_noop(self):
-        original = get_settings().pro_model
-        with settings_override({}):
-            assert get_settings().pro_model == original
+        original = config_module.get_settings().pro_model
+        with config_module.settings_override({}):
+            assert config_module.get_settings().pro_model == original
 
     def test_none_values_ignored(self):
-        original = get_settings().pro_model
-        with settings_override({"pro_model": None}):
-            assert get_settings().pro_model == original
+        original = config_module.get_settings().pro_model
+        with config_module.settings_override({"pro_model": None}):
+            assert config_module.get_settings().pro_model == original

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -3,7 +3,7 @@
 import pytest
 
 from hr_breaker.filters import DataValidator, FilterRegistry
-from hr_breaker.filters.data_validator import validate_resume_data
+from hr_breaker.filters.data_validator import validate_html, validate_resume_data
 from hr_breaker.models import JobPosting, OptimizedResume, ResumeSource
 from hr_breaker.models.resume_data import (
     ResumeData,
@@ -68,6 +68,7 @@ def test_data_validator_priority():
 def test_data_validator_threshold():
     validator = DataValidator()
     assert validator.threshold == 1.0
+
 
 
 # --- validate_resume_data Function Tests ---

--- a/tests/test_extraction_worker.py
+++ b/tests/test_extraction_worker.py
@@ -1,0 +1,49 @@
+import os
+from unittest.mock import patch
+
+import hr_breaker.config as config_module
+from hr_breaker.services.extraction_worker import ExtractionWorker
+from hr_breaker.services.profile_store import ProfileStore
+
+
+def test_extraction_worker_applies_overrides_during_background_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        doc = store.add_note(profile.id, title="Resume", content_text="resume text")
+        observed = {}
+
+        async def fake_extract_document_content(self, profile_id, document_id):
+            observed["profile_id"] = profile_id
+            observed["document_id"] = document_id
+            observed["api_key"] = os.environ.get("OPENAI_API_KEY")
+            observed["api_base"] = os.environ.get("OPENAI_API_BASE")
+            return self.get_document(profile_id, document_id)
+
+        worker = ExtractionWorker(max_workers=1)
+        with patch(
+            "hr_breaker.services.profile_store.ProfileStore.extract_document_content",
+            new=fake_extract_document_content,
+        ):
+            worker._run(
+                profile.id,
+                doc.id,
+                overrides={
+                    "api_keys": {"openai": "sk-test"},
+                    "openai_api_base": "https://example.test/v1",
+                },
+            )
+
+        assert observed == {
+            "profile_id": profile.id,
+            "document_id": doc.id,
+            "api_key": "sk-test",
+            "api_base": "https://example.test/v1",
+        }
+        assert worker.get_status(doc.id) == "done"
+    finally:
+        config_module.clear_settings_cache()

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,17 @@
+import pytest
+
+from hr_breaker.agents.extractor import extract_document
+import hr_breaker.config as config_module
+
+
+@pytest.mark.asyncio
+async def test_extract_document_fails_fast_without_openai_key(monkeypatch):
+    monkeypatch.setenv("FLASH_MODEL", "openai/gpt-5.3-codex")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    config_module.clear_settings_cache()
+    try:
+        with pytest.raises(RuntimeError, match="Missing API key for extraction model 'openai/gpt-5.3-codex'.*OPENAI_API_KEY"):
+            await extract_document("Candidate resume text")
+    finally:
+        config_module.clear_settings_cache()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,13 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from hr_breaker.filters import HallucinationChecker, FilterRegistry, KeywordMatcher
+from hr_breaker.filters import (
+    FilterRegistry,
+    HallucinationChecker,
+    KeywordMatcher,
+    VectorSimilarityMatcher,
+ )
 from hr_breaker.models import JobPosting, OptimizedResume, ResumeSource
 
 
@@ -100,3 +107,51 @@ def test_filter_priorities_unique():
                 f"Duplicate priority {priority}: {seen[priority]} and {name}"
             )
         seen[priority] = name
+
+
+@pytest.mark.asyncio
+async def test_vector_similarity_matcher_uses_settings_embedding_config(
+    source_resume, job_posting
+ ):
+    optimized = OptimizedResume(
+        html="<div>Test</div>",
+        source_checksum=source_resume.checksum,
+        pdf_text="Python Django PostgreSQL",
+    )
+    matcher = VectorSimilarityMatcher()
+    embedding_response = type(
+        "EmbeddingResponse",
+        (),
+        {
+            "data": [
+                {"embedding": [1.0, 0.0]},
+                {"embedding": [1.0, 0.0]},
+            ]
+        },
+    )()
+
+    mock_settings = MagicMock()
+    mock_settings.embedding_model = "openai/text-embedding-3-small"
+    mock_settings.embedding_output_dimensionality = 768
+    mock_settings.filter_vector_threshold = 0.4
+
+    with (
+        patch(
+            "hr_breaker.filters.vector_similarity_matcher.get_settings",
+            return_value=mock_settings,
+        ),
+        patch(
+            "hr_breaker.filters.vector_similarity_matcher.run_with_retry",
+            new_callable=AsyncMock,
+            return_value=embedding_response,
+        ) as mock_retry,
+    ):
+        result = await matcher.evaluate(optimized, job_posting, source_resume)
+
+    assert result.passed
+    mock_retry.assert_awaited_once_with(
+        matcher.evaluate.__globals__["litellm_aembedding"],
+        model="openai/text-embedding-3-small",
+        input=["Python Django PostgreSQL", "Backend Engineer  Python Django PostgreSQL"],
+        dimensions=768,
+    )

--- a/tests/test_litellm_patch.py
+++ b/tests/test_litellm_patch.py
@@ -1,8 +1,12 @@
 """Tests for litellm vision patch."""
 
+import asyncio
 import base64
+import inspect
 
+import litellm
 import pytest
+from litellm.litellm_core_utils.logging_worker import LoggingWorker
 from pydantic_ai.messages import (
     BinaryContent,
     ImageUrl,
@@ -12,10 +16,13 @@ from pydantic_ai.messages import (
     TextPart,
     ToolCallPart,
     UserPromptPart,
-)
+    )
 
-from hr_breaker.litellm_patch import _convert_user_content, _patched_map_messages
-
+from hr_breaker.litellm_patch import (
+    _convert_user_content,
+    _patched_map_messages,
+    apply,
+ )
 
 class TestConvertUserContent:
     def test_plain_string(self):
@@ -131,3 +138,88 @@ class TestPatchedMapMessages:
         assert msg["role"] == "assistant"
         assert len(msg["tool_calls"]) == 1
         assert msg["tool_calls"][0]["function"]["name"] == "check_length"
+
+
+    @pytest.mark.asyncio
+    async def test_system_messages_are_hoisted_before_user_messages(self):
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="Hello first")]),
+            ModelRequest(parts=[SystemPromptPart(content="Late system")]),
+        ]
+
+        result = await _patched_map_messages(None, messages)
+        assert result == [
+            {"role": "system", "content": "Late system"},
+            {"role": "user", "content": "Hello first"},
+        ]
+
+@pytest.fixture(autouse=True)
+def _reset_litellm_callbacks():
+    original_success = list(litellm.success_callback)
+    original_async_success = list(litellm._async_success_callback)
+    original_failure = list(litellm.failure_callback)
+    original_async_failure = list(litellm._async_failure_callback)
+    apply()
+    litellm.success_callback[:] = []
+    litellm._async_success_callback[:] = []
+    litellm.failure_callback[:] = []
+    litellm._async_failure_callback[:] = []
+    try:
+        yield
+    finally:
+        litellm.success_callback[:] = original_success
+        litellm._async_success_callback[:] = original_async_success
+        litellm.failure_callback[:] = original_failure
+        litellm._async_failure_callback[:] = original_async_failure
+
+
+class TestLoggingWorkerPatch:
+    @pytest.mark.asyncio
+    async def test_skips_worker_when_no_async_callbacks_exist(self):
+        worker = LoggingWorker()
+
+        async def noop():
+            return None
+
+        coro = noop()
+        worker.ensure_initialized_and_enqueue(coro)
+        await asyncio.sleep(0)
+
+        assert worker._worker_task is None
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+
+    @pytest.mark.asyncio
+    async def test_starts_worker_when_async_callbacks_exist(self):
+        worker = LoggingWorker()
+        litellm._async_success_callback.append(object())
+        processed = asyncio.Event()
+
+        async def noop():
+            processed.set()
+            return None
+
+        worker.ensure_initialized_and_enqueue(noop())
+        await asyncio.wait_for(processed.wait(), timeout=1)
+
+        assert worker._worker_task is not None
+        await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_starts_worker_when_dynamic_async_callbacks_exist(self):
+        worker = LoggingWorker()
+        processed = asyncio.Event()
+
+        class FakeLoggingObj:
+            dynamic_async_success_callbacks = [object()]
+            dynamic_async_failure_callbacks = []
+
+            async def async_success_handler(self):
+                processed.set()
+                return None
+
+        logging_obj = FakeLoggingObj()
+        worker.ensure_initialized_and_enqueue(logging_obj.async_success_handler())
+        await asyncio.wait_for(processed.wait(), timeout=1)
+
+        assert worker._worker_task is not None
+        await worker.stop()

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,0 +1,199 @@
+"""Tests for provider model discovery."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hr_breaker.services.llm_providers import (
+    _fetch_gemini_models,
+    fetch_provider_catalog,
+    _fetch_anthropic_models,
+    _litellm_prefix,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_uses_google_api_key_fallback_for_gemini(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_gemini_models",
+        new=AsyncMock(return_value=([{"value": "gemini/gemini-2.5-pro", "label": "Gemini 2.5 Pro"}], [])),
+    ) as mock_fetch:
+        result = await fetch_provider_catalog("gemini")
+
+    mock_fetch.assert_awaited_once_with("google-key")
+    assert result["status"]["state"] == "connected"
+    assert result["chat_models"] == [{"value": "gemini/gemini-2.5-pro", "label": "Gemini 2.5 Pro"}]
+    assert result["embedding_models"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_gemini_models_uses_query_param_auth_only():
+    recorded = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"models": []}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params=None, headers=None):
+            recorded["url"] = url
+            recorded["params"] = params
+            recorded["headers"] = headers
+            return FakeResponse()
+
+    with patch("hr_breaker.services.llm_providers.httpx.AsyncClient", return_value=FakeClient()):
+        await _fetch_gemini_models("gem-test")
+
+    assert recorded == {
+        "url": "https://generativelanguage.googleapis.com/v1beta/models",
+        "params": {"key": "gem-test"},
+        "headers": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_uses_custom_base_url_for_openai_compatible_provider():
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_openai_models",
+        new=AsyncMock(return_value=([{"value": "openai/gpt-4.1-mini", "label": "gpt-4.1-mini"}], [])),
+    ) as mock_fetch:
+        result = await fetch_provider_catalog(
+            provider="custom",
+            api_key="sk-test",
+            base_url="https://example.test/v1/",
+        )
+
+    mock_fetch.assert_awaited_once_with("sk-test", "https://example.test/v1", litellm_prefix="openai/")
+    assert result["status"]["state"] == "connected"
+    assert result["chat_models"] == [{"value": "openai/gpt-4.1-mini", "label": "gpt-4.1-mini"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_surfaces_http_error_detail():
+    response = httpx.Response(
+        401,
+        request=httpx.Request("GET", "https://example.test/v1/models"),
+        json={"error": {"message": "Invalid API key"}},
+    )
+    error = httpx.HTTPStatusError("Unauthorized", request=response.request, response=response)
+
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_openai_models",
+        new=AsyncMock(side_effect=error),
+    ):
+        result = await fetch_provider_catalog(provider="openai", api_key="sk-test")
+
+    assert result["status"] == {
+        "state": "warning",
+        "message": "Connection failed (401)",
+        "detail": "Invalid API key",
+    }
+    assert result["chat_models"] == []
+    assert result["embedding_models"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_surfaces_request_error_detail():
+    error = httpx.RequestError(
+        "Timed out while connecting",
+        request=httpx.Request("GET", "https://example.test/v1/models"),
+    )
+
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_openai_models",
+        new=AsyncMock(side_effect=error),
+    ):
+        result = await fetch_provider_catalog(provider="openai", api_key="sk-test")
+
+    assert result["status"] == {
+        "state": "warning",
+        "message": "Connection failed",
+        "detail": "Timed out while connecting",
+    }
+    assert result["chat_models"] == []
+    assert result["embedding_models"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_uses_anthropic_models_endpoint():
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_anthropic_models",
+        new=AsyncMock(return_value=([{"value": "anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}], [])),
+    ) as mock_fetch:
+        result = await fetch_provider_catalog(provider="anthropic", api_key="ant-test")
+
+    mock_fetch.assert_awaited_once_with("ant-test", "https://api.anthropic.com")
+    assert result["status"]["state"] == "connected"
+    assert result["chat_models"] == [{"value": "anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}]
+    assert result["embedding_models"] == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_anthropic_models_uses_required_headers_only():
+    recorded = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "data": [
+                    {"id": "claude-sonnet-4", "display_name": "Claude Sonnet 4"},
+                ]
+            }
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            recorded["url"] = url
+            recorded["headers"] = headers
+            return FakeResponse()
+
+    with patch("hr_breaker.services.llm_providers.httpx.AsyncClient", return_value=FakeClient()):
+        chat, embed = await _fetch_anthropic_models("ant-test", "https://api.anthropic.com")
+
+    assert chat == [{"value": "anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}]
+    assert embed == []
+    assert recorded == {
+        "url": "https://api.anthropic.com/v1/models",
+        "headers": {
+            "x-api-key": "ant-test",
+            "anthropic-version": "2023-06-01",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_provider_catalog_uses_moonshot_openai_compatible_endpoint():
+    with patch(
+        "hr_breaker.services.llm_providers._fetch_openai_models",
+        new=AsyncMock(return_value=([{"value": "moonshot/kimi-k2", "label": "kimi-k2"}], [])),
+    ) as mock_fetch:
+        result = await fetch_provider_catalog(provider="moonshot", api_key="moon-test")
+
+    mock_fetch.assert_awaited_once_with("moon-test", "https://api.moonshot.ai/v1", litellm_prefix="moonshot/")
+    assert result["status"]["state"] == "connected"
+    assert result["chat_models"] == [{"value": "moonshot/kimi-k2", "label": "kimi-k2"}]
+
+
+def test_litellm_prefix_supports_moonshot():
+    assert _litellm_prefix("moonshot") == "moonshot/"

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -197,3 +197,31 @@ async def test_fetch_provider_catalog_uses_moonshot_openai_compatible_endpoint()
 
 def test_litellm_prefix_supports_moonshot():
     assert _litellm_prefix("moonshot") == "moonshot/"
+
+@pytest.mark.asyncio
+async def test_fetch_anthropic_models_avoids_double_v1_suffix():
+    recorded = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": []}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            recorded["url"] = url
+            recorded["headers"] = headers
+            return FakeResponse()
+
+    with patch("hr_breaker.services.llm_providers.httpx.AsyncClient", return_value=FakeClient()):
+        await _fetch_anthropic_models("ant-test", "https://api.anthropic.com/v1/")
+
+    assert recorded["url"] == "https://api.anthropic.com/v1/models"

--- a/tests/test_optimization_telemetry.py
+++ b/tests/test_optimization_telemetry.py
@@ -117,7 +117,7 @@ def test_report_usage_keeps_zero_usage_available_for_non_embedding_models():
         report_usage("LLMChecker", "openai/gpt-5.3-codex", usage)
 
     assert len(captured) == 1
-    assert captured[0]["usage_available"] is True
+    assert captured[0]["usage_available"] is False
 
 
 def test_report_usage_maps_prompt_completion_tokens_for_litellm_usage():

--- a/tests/test_optimization_telemetry.py
+++ b/tests/test_optimization_telemetry.py
@@ -1,0 +1,139 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hr_breaker.utils.optimization_telemetry import (
+    accumulate_usage_totals,
+    report_usage,
+    run_tracked_agent,
+    telemetry_reporter,
+    zero_usage_totals,
+)
+
+
+def test_accumulate_usage_totals_adds_usage_entry_values():
+    totals = zero_usage_totals()
+    updated = accumulate_usage_totals(
+        totals,
+        {
+            "requests": 2,
+            "input_tokens": 300,
+            "output_tokens": 40,
+            "cache_read_tokens": 120,
+            "cache_write_tokens": 10,
+        },
+    )
+
+    assert updated == {
+        "requests": 2,
+        "input_tokens": 300,
+        "output_tokens": 40,
+        "cache_read_tokens": 120,
+        "cache_write_tokens": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_tracked_agent_reports_usage():
+    captured = []
+    usage = SimpleNamespace(
+        requests=1,
+        input_tokens=123,
+        output_tokens=45,
+        cache_read_tokens=67,
+        cache_write_tokens=8,
+    )
+    result = SimpleNamespace(output="ok", usage=lambda: usage)
+    agent = SimpleNamespace(
+        model=SimpleNamespace(model_name="openai/gpt-5.3-codex"),
+        run=AsyncMock(return_value=result),
+    )
+
+    with telemetry_reporter(captured.append):
+        observed = await run_tracked_agent(agent, "hello", component="LLMChecker")
+
+    assert observed is result
+    agent.run.assert_called_once_with("hello")
+    assert len(captured) == 1
+    assert captured[0]["component"] == "LLMChecker"
+    assert captured[0]["model"] == "openai/gpt-5.3-codex"
+    assert captured[0]["provider"] == "openai"
+    assert captured[0]["requests"] == 1
+    assert captured[0]["input_tokens"] == 123
+    assert captured[0]["output_tokens"] == 45
+    assert captured[0]["cache_read_tokens"] == 67
+    assert captured[0]["cache_write_tokens"] == 8
+
+
+
+def test_accumulate_usage_totals_skips_unavailable_usage_entries():
+    totals = zero_usage_totals()
+    updated = accumulate_usage_totals(
+        totals,
+        {
+            "requests": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "usage_available": False,
+        },
+    )
+
+    assert updated == totals
+
+
+def test_report_usage_marks_zero_only_embedding_usage_unavailable():
+    captured = []
+    usage = SimpleNamespace(
+        requests=0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+
+    with telemetry_reporter(captured.append):
+        report_usage("VectorSimilarityMatcher", "gemini/gemini-embedding-2-preview", usage)
+
+    assert len(captured) == 1
+    assert captured[0]["usage_available"] is False
+    assert captured[0]["requests"] == 0
+    assert captured[0]["input_tokens"] == 0
+
+
+def test_report_usage_keeps_zero_usage_available_for_non_embedding_models():
+    captured = []
+    usage = SimpleNamespace(
+        requests=0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+
+    with telemetry_reporter(captured.append):
+        report_usage("LLMChecker", "openai/gpt-5.3-codex", usage)
+
+    assert len(captured) == 1
+    assert captured[0]["usage_available"] is True
+
+
+def test_report_usage_maps_prompt_completion_tokens_for_litellm_usage():
+    captured = []
+    usage = SimpleNamespace(
+        prompt_tokens=691,
+        completion_tokens=1071,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+
+    with telemetry_reporter(captured.append):
+        report_usage("VectorSimilarityMatcher", "openai/text-embedding-3-small", usage)
+
+    assert len(captured) == 1
+    assert captured[0]["usage_available"] is True
+    assert captured[0]["requests"] == 1
+    assert captured[0]["input_tokens"] == 691
+    assert captured[0]["output_tokens"] == 1071

--- a/tests/test_optimizer_language.py
+++ b/tests/test_optimizer_language.py
@@ -4,43 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from hr_breaker.models import JobPosting, ResumeSource, IterationContext, OptimizedResume, ValidationResult, FilterResult
-from hr_breaker.models.language import get_language, get_language_safe, resolve_target_language, LANGUAGE_MODES
-
-
-class TestLanguageHelpers:
-
-    def test_get_language_safe_known(self):
-        assert get_language_safe("en").code == "en"
-        assert get_language_safe("ru").code == "ru"
-
-    def test_get_language_safe_unknown(self):
-        assert get_language_safe("xx").code == "en"
-        assert get_language_safe(None).code == "en"
-        assert get_language_safe("").code == "en"
-
-    def test_resolve_from_job(self):
-        lang = resolve_target_language("from_job", "ru", "en")
-        assert lang.code == "ru"
-
-    def test_resolve_from_resume(self):
-        lang = resolve_target_language("from_resume", "ru", "en")
-        assert lang.code == "en"
-
-    def test_resolve_fixed_code(self):
-        lang = resolve_target_language("ru", "en", "en")
-        assert lang.code == "ru"
-
-    def test_resolve_from_job_unknown(self):
-        lang = resolve_target_language("from_job", "xx", "en")
-        assert lang.code == "en"
-
-    def test_language_modes_structure(self):
-        assert len(LANGUAGE_MODES) >= 4
-        values = [m["value"] for m in LANGUAGE_MODES]
-        assert "from_job" in values
-        assert "from_resume" in values
-        assert "en" in values
-        assert "ru" in values
+from hr_breaker.models.language import get_language
 
 
 class TestOptimizerLanguagePrompt:
@@ -61,8 +25,8 @@ class TestOptimizerLanguagePrompt:
         return IterationContext(iteration=0, original_resume=source.content)
 
     @pytest.mark.asyncio
-    async def test_english_language_instructions_when_none(self, job, source, context):
-        """English TARGET LANGUAGE block when language is None."""
+    async def test_no_language_instructions_when_none(self, job, source, context):
+        """No TARGET LANGUAGE block when language is None."""
         with patch("hr_breaker.agents.optimizer.get_optimizer_agent") as mock_get:
             mock_agent = AsyncMock()
             mock_result = MagicMock()
@@ -74,11 +38,11 @@ class TestOptimizerLanguagePrompt:
             await optimize_resume(source, job, context, language=None)
 
             prompt = mock_agent.run.call_args[0][0]
-            assert "TARGET LANGUAGE: English" in prompt
+            assert "TARGET LANGUAGE" not in prompt
 
     @pytest.mark.asyncio
-    async def test_english_language_instructions_when_english(self, job, source, context):
-        """English TARGET LANGUAGE block when language is English."""
+    async def test_no_language_instructions_when_english(self, job, source, context):
+        """No TARGET LANGUAGE block when language is English."""
         english = get_language("en")
         with patch("hr_breaker.agents.optimizer.get_optimizer_agent") as mock_get:
             mock_agent = AsyncMock()
@@ -91,7 +55,7 @@ class TestOptimizerLanguagePrompt:
             await optimize_resume(source, job, context, language=english)
 
             prompt = mock_agent.run.call_args[0][0]
-            assert "TARGET LANGUAGE: English" in prompt
+            assert "TARGET LANGUAGE" not in prompt
 
     @pytest.mark.asyncio
     async def test_russian_adds_language_instructions(self, job, source, context):
@@ -142,30 +106,3 @@ class TestOrchestrationPassesLanguage:
 
             assert mock_opt.call_args.kwargs.get("language") == russian
 
-    @pytest.mark.asyncio
-    async def test_source_language_passed_to_filters(self):
-        russian = get_language("ru")
-        english = get_language("en")
-        source = ResumeSource(content="John Doe\nPython dev")
-        job = JobPosting(
-            title="Backend Engineer", company="Acme",
-            requirements=["Python"], keywords=["python"],
-        )
-        mock_optimized = MagicMock()
-        mock_optimized.html = "<div>Тест</div>"
-        mock_optimized.data = None
-
-        with patch("hr_breaker.orchestration.optimize_resume", new_callable=AsyncMock) as mock_opt, \
-             patch("hr_breaker.orchestration._render_and_extract") as mock_render, \
-             patch("hr_breaker.orchestration.run_filters", new_callable=AsyncMock) as mock_filters:
-
-            mock_opt.return_value = mock_optimized
-            mock_render.return_value = mock_optimized
-            mock_filters.return_value = ValidationResult(results=[
-                FilterResult(filter_name="test", passed=True, score=1.0),
-            ])
-
-            from hr_breaker.orchestration import optimize_for_job
-            await optimize_for_job(source, job=job, language=russian, source_language=english, max_iterations=1)
-
-            assert mock_filters.call_args.kwargs.get("source_language") == english

--- a/tests/test_orchestration_logging.py
+++ b/tests/test_orchestration_logging.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+from hr_breaker.orchestration import (
+    _optimization_settings_summary_lines,
+    _optimizer_changes_log_message,
+)
+
+
+def test_optimization_settings_summary_lines_are_concise_and_safe():
+    settings = SimpleNamespace(
+        pro_model="openai/gpt-5.4",
+        flash_model="openai/gpt-5.3-codex",
+        embedding_model="gemini/gemini-embedding-2-preview",
+        reasoning_effort="medium",
+        gemini_api_key="secret-gemini-key",
+        openai_api_base="http://127.0.0.1:8317/v1",
+        cache_dir=".cache/resumes",
+    )
+
+    lines = _optimization_settings_summary_lines(
+        settings,
+        max_iterations=1,
+        parallel=True,
+        no_shame=False,
+    )
+
+    assert lines == [
+        "Pro model: openai/gpt-5.4 / openai",
+        "Flash model: openai/gpt-5.3-codex / openai",
+        "Embedding model: gemini/gemini-embedding-2-preview / gemini",
+        "Optimization mode: parallel, reasoning: medium, max iterations: 1, no-shame: False",
+    ]
+    for line in lines:
+        assert "secret-gemini-key" not in line
+        assert "openai_api_base" not in line
+        assert "cache_dir" not in line
+
+
+def test_optimizer_changes_log_message_uses_bullets():
+    assert _optimizer_changes_log_message(["First", "Second"]) == (
+        "Optimizer changes:\n"
+        "- First\n"
+        "- Second"
+    )
+
+
+def test_optimizer_changes_log_message_handles_empty_changes():
+    assert _optimizer_changes_log_message([]) == "Optimizer changes: none"

--- a/tests/test_profile_retrieval.py
+++ b/tests/test_profile_retrieval.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from hr_breaker.models import JobPosting, ProfileDocument
+from hr_breaker.services.profile_retrieval import rank_profile_documents
+
+
+@pytest.mark.asyncio
+async def test_rank_profile_documents_orders_by_relevance_without_embeddings():
+    job = JobPosting(
+        title="Machine Learning Engineer",
+        company="Acme",
+        requirements=["Python", "LLM", "Vector search"],
+        keywords=["python", "llm", "vector search"],
+        description="Build retrieval systems and production ML services.",
+    )
+    relevant = ProfileDocument(
+        profile_id="candidate",
+        kind="resume",
+        title="ML Resume",
+        source_name="ml_resume.md",
+        content_text="Built Python LLM retrieval services with vector search and ranking pipelines.",
+        timestamp=datetime(2026, 1, 2),
+    )
+    unrelated = ProfileDocument(
+        profile_id="candidate",
+        kind="note",
+        title="Music Club",
+        source_name="music.txt",
+        content_text="Organized campus music events and weekly rehearsals for the club.",
+        timestamp=datetime(2026, 1, 1),
+    )
+
+    with patch("hr_breaker.services.profile_retrieval._vector_scores", return_value=[None, None]):
+        ranked = await rank_profile_documents([unrelated, relevant], job)
+
+    assert [match.document.title for match in ranked] == ["ML Resume", "Music Club"]
+    assert ranked[0].score > ranked[1].score
+    assert "vector search" in ranked[0].snippet.lower()
+
+
+@pytest.mark.asyncio
+async def test_rank_profile_documents_returns_all_selected_docs():
+    """rank_profile_documents scores every selected doc — callers decide how many to show."""
+    job = JobPosting(
+        title="Backend Engineer",
+        company="Acme",
+        requirements=["Python"],
+        keywords=["python"],
+        description="Build APIs.",
+    )
+    documents = [
+        ProfileDocument(
+            profile_id="candidate",
+            kind="resume",
+            title=f"Resume {index}",
+            source_name=f"resume_{index}.md",
+            content_text=f"Python API work #{index}",
+        )
+        for index in range(3)
+    ]
+
+    with patch("hr_breaker.services.profile_retrieval._vector_scores", return_value=[None, None, None]):
+        ranked = await rank_profile_documents(documents, job)
+
+    assert len(ranked) == 3

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -82,3 +82,18 @@ async def test_extract_document_content_does_not_recreate_deleted_document(tmp_p
 
     assert updated is None
     assert store.get_document(profile.id, doc.id) is None
+
+def test_profile_store_rejects_path_traversal_ids(tmp_path):
+    store = ProfileStore(root_dir=tmp_path / "profiles")
+    outside_dir = tmp_path / "outside-profile"
+    outside_dir.mkdir(parents=True)
+    (outside_dir / "profile.json").write_text("{}", encoding="utf-8")
+
+    assert store.get_profile("../outside-profile") is None
+    assert store.list_documents("../outside-profile") == []
+    assert store.get_document("../outside-profile", "doc") is None
+
+    with pytest.raises(ValueError):
+        store.delete_profile("../outside-profile")
+
+    assert (outside_dir / "profile.json").exists()

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -1,3 +1,8 @@
+from unittest.mock import patch
+
+import pytest
+
+from hr_breaker.models.profile import DocumentExtraction
 from hr_breaker.services.profile_store import ProfileStore
 
 
@@ -60,3 +65,20 @@ def test_profile_store_deduplicates_matching_uploads_and_updates_timestamp(tmp_p
     assert len(documents) == 2
     assert {document.kind for document in documents} == {"resume", "note"}
     assert note.source_name == "Hackathon"
+
+
+@pytest.mark.asyncio
+async def test_extract_document_content_does_not_recreate_deleted_document(tmp_path):
+    store = ProfileStore(root_dir=tmp_path)
+    profile = store.create_profile("Jane Doe")
+    doc = store.add_note(profile.id, title="Resume", content_text="raw text")
+
+    async def fake_extract_document(_content):
+        store.remove_document(profile.id, doc.id)
+        return DocumentExtraction(summary=["Recovered facts"])
+
+    with patch("hr_breaker.agents.extractor.extract_document", new=fake_extract_document):
+        updated = await store.extract_document_content(profile.id, doc.id)
+
+    assert updated is None
+    assert store.get_document(profile.id, doc.id) is None

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -1,0 +1,62 @@
+from hr_breaker.services.profile_store import ProfileStore
+
+
+def test_profile_store_creates_and_lists_profiles(tmp_path):
+    store = ProfileStore(root_dir=tmp_path)
+
+    created = store.create_profile("Jane Doe")
+    profiles = store.list_profiles()
+
+    assert created.id == "jane_doe"
+    assert [profile.display_name for profile in profiles] == ["Jane Doe"]
+    assert store.get_profile(created.id) is not None
+
+
+def test_profile_store_persists_uploads_and_assets(tmp_path):
+    store = ProfileStore(root_dir=tmp_path)
+    profile = store.create_profile("Jane Doe")
+
+    document = store.add_upload(
+        profile.id,
+        filename="resume.md",
+        data=b"# Jane Doe\nPython engineer",
+        mime_type="text/markdown",
+    )
+
+    documents = store.list_documents(profile.id)
+    reloaded = store.get_document(profile.id, document.id)
+
+    assert len(documents) == 1
+    assert reloaded is not None
+    assert reloaded.kind == "resume"
+    assert reloaded.content_text == "# Jane Doe\nPython engineer"
+    assert reloaded.metadata["original_filename"] == "resume.md"
+    assert (tmp_path / profile.id / reloaded.metadata["asset_path"]).exists()
+
+
+def test_profile_store_deduplicates_matching_uploads_and_updates_timestamp(tmp_path):
+    store = ProfileStore(root_dir=tmp_path)
+    profile = store.create_profile("Jane Doe")
+
+    first = store.add_upload(
+        profile.id,
+        filename="resume.md",
+        data=b"# Jane Doe\nPython engineer",
+    )
+    second = store.add_upload(
+        profile.id,
+        filename="resume.md",
+        data=b"# Jane Doe\nPython engineer",
+    )
+    note = store.add_note(
+        profile.id,
+        title="Hackathon",
+        content_text="Won first place at the AI systems hackathon.",
+    )
+
+    documents = store.list_documents(profile.id)
+
+    assert first.id == second.id
+    assert len(documents) == 2
+    assert {document.kind for document in documents} == {"resume", "note"}
+    assert note.source_name == "Hackathon"

--- a/tests/test_profile_synthesis.py
+++ b/tests/test_profile_synthesis.py
@@ -74,12 +74,13 @@ def test_fallback_whole_doc_skip_not_bisect():
     assert "x" * 100 not in source.content
 
 
-def test_fallback_top1_when_all_over_budget():
-    """If every doc exceeds budget, include the highest-priority one in full."""
+def test_fallback_omits_all_docs_when_everything_is_over_budget():
+    """If every doc exceeds budget, omit them rather than blowing past the cap."""
     profile = _make_profile()
     doc = _make_doc(content="x" * 15000)
     source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
-    assert "x" * 100 in source.content  # top-1 included regardless
+    assert "x" * 100 not in source.content
+    assert "Note: omitted (over budget): Resume" in source.content
 
 
 def test_fallback_uses_last_name_without_duplication():

--- a/tests/test_profile_synthesis.py
+++ b/tests/test_profile_synthesis.py
@@ -1,0 +1,395 @@
+import pytest
+from unittest.mock import patch
+
+from hr_breaker.models import (
+    DocumentExtraction,
+    EducationEntry,
+    ExperienceEntry,
+    PersonalInfo,
+    Profile,
+    ProfileDocument,
+    RankedProfileDocument,
+    SkillsEntry,
+)
+from hr_breaker.models.job_posting import JobPosting
+from hr_breaker.services.profile_retrieval import (
+    _format_extraction,
+    _merge_extractions,
+    rank_profile_documents,
+    synthesize_profile_resume_source,
+)
+
+
+def _make_profile(**kwargs):
+    defaults = dict(id="jane_doe", display_name="Jane Doe", first_name="Jane", last_name="Doe")
+    return Profile(**{**defaults, **kwargs})
+
+
+def _make_doc(profile_id="jane_doe", *, kind="resume", title="Resume", content="some content", metadata=None):
+    return ProfileDocument(
+        profile_id=profile_id,
+        kind=kind,
+        title=title,
+        source_name=f"{title}.md",
+        content_text=content,
+        metadata=metadata or {},
+    )
+
+
+def _ranked(doc, score=0.5):
+    return RankedProfileDocument(
+        document=doc,
+        lexical_score=score,
+        keyword_score=score,
+        vector_score=None,
+        score=score,
+        snippet="",
+    )
+
+
+# --- Whole-doc fallback (no extractions) ---
+
+def test_fallback_includes_profile_header():
+    profile = _make_profile(instructions="Focus on ML.")
+    doc = _make_doc(content="Built Python ML systems.")
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+    assert source.first_name == "Jane"
+    assert source.last_name == "Doe"
+    assert "Focus on ML." in source.content
+    assert "Profile documents:" in source.content
+    assert "Built Python ML systems." in source.content
+
+
+def test_fallback_whole_doc_skip_not_bisect():
+    """Over-budget docs are skipped whole; smaller subsequent docs still fit."""
+    profile = _make_profile()
+    big = _make_doc(title="Big", content="x" * 15000)
+    small = _make_doc(title="Small", content="small content", kind="note")
+    source = synthesize_profile_resume_source(profile, [big, small], [_ranked(big, 0.9), _ranked(small, 0.1)])
+    # Small doc fits, big is skipped whole
+    assert "small content" in source.content
+    assert "omitted" in source.content
+    assert "Big" in source.content   # mentioned in omitted note
+    # Content must not end mid-word (no bisection)
+    assert "x" * 100 not in source.content
+
+
+def test_fallback_top1_when_all_over_budget():
+    """If every doc exceeds budget, include the highest-priority one in full."""
+    profile = _make_profile()
+    doc = _make_doc(content="x" * 15000)
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+    assert "x" * 100 in source.content  # top-1 included regardless
+
+
+def test_fallback_uses_last_name_without_duplication():
+    profile = _make_profile(first_name=None, last_name="Doe", display_name="Candidate")
+    doc = _make_doc(content="Built Python ML systems.")
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+
+    assert source.first_name is None
+    assert source.last_name == "Doe"
+
+
+# --- Extraction path ---
+
+def _extraction(**kwargs):
+    defaults = dict(
+        summary=[], experience=[], education=[],
+        skills=SkillsEntry(), projects=[], publications=[],
+    )
+    return DocumentExtraction(**{**defaults, **kwargs})
+
+
+def test_extraction_path_used_when_present():
+    profile = _make_profile()
+    ext = _extraction(summary=["ML engineer with 8 years experience."])
+    doc = _make_doc(metadata={"extraction": ext.model_dump()})
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+    assert "ML engineer with 8 years experience." in source.content
+    assert "## Summary" in source.content
+    # Whole-doc section header should NOT appear
+    assert "Profile documents:" not in source.content
+
+
+def test_extraction_path_sets_contact_info_in_content():
+    profile = _make_profile()
+    ext = _extraction(
+        personal_info=PersonalInfo(
+            email="candidate@example.test",
+            phone="555-0100",
+            linkedin="mock-candidate",
+            github="mock-candidate",
+            website="portfolio.example.test",
+        ),
+        summary=["Researcher."],
+    )
+    doc = _make_doc(metadata={"extraction": ext.model_dump()})
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+
+    assert "Candidate name: Jane Doe" in source.content
+    assert "mock-candidate" in source.content
+    assert "portfolio.example.test" in source.content
+
+
+def test_extraction_path_uses_profile_display_name_for_missing_last_name():
+    profile = _make_profile(first_name="Mock", last_name=None, display_name="Mock Candidate")
+    ext = _extraction(
+        personal_info=PersonalInfo(name="Mock"),
+        summary=["Policy researcher."],
+    )
+    doc = _make_doc(metadata={"extraction": ext.model_dump()})
+    source = synthesize_profile_resume_source(profile, [doc], [_ranked(doc)])
+
+    assert source.first_name == "Mock"
+    assert source.last_name == "Candidate"
+    assert "Candidate name: Mock Candidate" in source.content
+
+
+def test_extraction_path_notes_missing_extractions():
+    profile = _make_profile()
+    ext = _extraction(summary=["Data scientist."])
+    doc_with = _make_doc(title="CV", metadata={"extraction": ext.model_dump()})
+    doc_without = _make_doc(title="Note", kind="note", content="extra context")
+    source = synthesize_profile_resume_source(profile, [doc_with, doc_without], [_ranked(doc_with)])
+    assert "Data scientist." in source.content
+    assert "extraction unavailable" in source.content
+    assert "Note" in source.content
+
+
+# --- _merge_extractions ---
+
+def test_merge_deduplicates_experience():
+    exp = ExperienceEntry(employer="Acme", title="Engineer", start="2020", end="Present", bullets=["Built things"])
+    ext1 = _extraction(experience=[exp])
+    ext2 = _extraction(experience=[exp])  # exact duplicate
+    merged = _merge_extractions([ext1, ext2])
+    assert len(merged.experience) == 1
+
+
+def test_merge_deduplicates_skills():
+    ext1 = _extraction(skills=SkillsEntry(technical=["Python", "SQL"]))
+    ext2 = _extraction(skills=SkillsEntry(technical=["SQL", "Go"]))
+    merged = _merge_extractions([ext1, ext2])
+    assert set(merged.skills.technical) == {"Go", "Python", "SQL"}
+
+
+def test_merge_sorts_experience_present_first():
+    old = ExperienceEntry(employer="A", title="Dev", start="2015", end="2018", bullets=[])
+    current = ExperienceEntry(employer="B", title="Lead", start="2021", end="Present", bullets=[])
+    merged = _merge_extractions([_extraction(experience=[old, current])])
+    assert merged.experience[0].end == "Present"
+
+
+# --- _format_extraction ---
+
+def test_format_extraction_sections():
+    ext = DocumentExtraction(
+        summary=["Experienced ML engineer."],
+        experience=[ExperienceEntry(employer="Acme", title="MLE", start="2020", end="Present", bullets=["Led infra"])],
+        education=[EducationEntry(institution="MIT", degree="BS", field="CS", start="2016", end="2020")],
+        skills=SkillsEntry(technical=["Python"], certifications=["AWS SAA"]),
+        projects=[],
+        publications=["Smith et al. 2023"],
+    )
+    text = _format_extraction(ext)
+    assert "## Summary" in text
+    assert "Experienced ML engineer." in text
+    assert "## Experience" in text
+    assert "Acme — MLE | 2020 – Present" in text
+    assert "Led infra" in text
+    assert "## Education" in text
+    assert "MIT" in text
+    assert "## Skills" in text
+    assert "Python" in text
+    assert "AWS SAA" in text
+    assert "## Publications" in text
+    assert "Smith et al. 2023" in text
+
+
+def test_format_extraction_contact():
+    ext = DocumentExtraction(
+        personal_info=PersonalInfo(email="x@y.com", linkedin="linkedin.com/in/x", github="github.com/x"),
+    )
+    text = _format_extraction(ext)
+    assert "## Contact" in text
+    assert "x@y.com" in text
+    assert "linkedin.com/in/x" in text
+    assert "github.com/x" in text
+
+
+def test_merge_contact_first_non_none():
+    ext1 = DocumentExtraction(personal_info=PersonalInfo(email="a@b.com"))
+    ext2 = DocumentExtraction(personal_info=PersonalInfo(email="c@d.com", phone="123"))
+    merged = _merge_extractions([ext1, ext2])
+    assert merged.personal_info.email == "a@b.com"  # first wins
+    assert merged.personal_info.phone == "123"       # filled from second
+
+
+def test_merge_preserves_name_from_first_extraction():
+    """name field must be merged like email/phone — it was previously missing from the loop."""
+    ext1 = DocumentExtraction(personal_info=PersonalInfo(name="Alice Smith", email="alice@example.test"))
+    ext2 = DocumentExtraction(personal_info=PersonalInfo(phone="555-0100"))
+    merged = _merge_extractions([ext1, ext2])
+    assert merged.personal_info.name == "Alice Smith"
+    assert merged.personal_info.email == "alice@example.test"
+    assert merged.personal_info.phone == "555-0100"
+
+
+def test_synthesize_with_empty_ranked_and_unextracted_doc():
+    """synthesize_profile_resume_source must not crash when ranked=[] and unextracted docs exist."""
+    profile = _make_profile()
+    ext = _extraction(summary=["Senior engineer."])
+    doc_extracted = _make_doc(title="CV", metadata={"extraction": ext.model_dump()})
+    doc_raw = _make_doc(title="Note", kind="note", content="UniqueRawContent")
+
+    # Pass empty ranked list — should not crash, raw doc should still appear
+    source = synthesize_profile_resume_source(profile, [doc_extracted, doc_raw], [])
+    assert "Senior engineer." in source.content
+    assert "UniqueRawContent" in source.content or "Note" in source.content
+
+
+def test_merge_caps_summaries():
+    ext = DocumentExtraction(summary=["S1", "S2", "S3", "S4"])
+    merged = _merge_extractions([ext])
+    assert len(merged.summary) == 2
+
+
+def test_merge_experience_unions_bullets_for_same_role():
+    """Same role across two docs should merge bullets, not drop the second entry."""
+    exp1 = ExperienceEntry(employer="Acme", title="Engineer", start="2020", end="2022", bullets=["Built API"])
+    exp2 = ExperienceEntry(employer="Acme", title="Engineer", start="2020", end="2022", bullets=["Led migration"])
+    merged = _merge_extractions([_extraction(experience=[exp1]), _extraction(experience=[exp2])])
+    assert len(merged.experience) == 1
+    bullets = merged.experience[0].bullets
+    assert "Built API" in bullets
+    assert "Led migration" in bullets
+
+
+def test_merge_experience_prefers_more_specific_end_date():
+    """When two entries match, the more recent/specific end date wins."""
+    exp_present = ExperienceEntry(employer="Acme", title="Engineer", start="2020", end="Present", bullets=[])
+    exp_old = ExperienceEntry(employer="Acme", title="Engineer", start="2020", end="2022", bullets=[])
+    merged = _merge_extractions([_extraction(experience=[exp_old]), _extraction(experience=[exp_present])])
+    assert merged.experience[0].end == "Present"
+
+
+def test_merge_education_unions_notes_and_fills_dates():
+    """Same degree across two docs merges notes and fills in missing dates."""
+    edu1 = EducationEntry(institution="MIT", degree="BS", field="CS", start="2016", end=None, notes=["GPA 3.9"])
+    edu2 = EducationEntry(institution="MIT", degree="BS", field=None, start=None, end="2020", notes=["Dean's list"])
+    merged = _merge_extractions([_extraction(education=[edu1]), _extraction(education=[edu2])])
+    assert len(merged.education) == 1
+    edu = merged.education[0]
+    assert edu.end == "2020"
+    assert edu.start == "2016"
+    assert edu.field == "CS"
+    assert "GPA 3.9" in edu.notes
+    assert "Dean's list" in edu.notes
+
+
+# --- Integration: mixed extracted + unextracted docs ---
+
+def test_mixed_mode_includes_raw_text_of_unextracted_docs():
+    """Selected docs without extraction must still appear as raw text in synthesis output."""
+    profile = _make_profile()
+    ext = _extraction(summary=["Senior engineer."])
+    doc_extracted = _make_doc(title="CV", metadata={"extraction": ext.model_dump()})
+    doc_raw = _make_doc(title="Hackathon note", kind="note", content="Won first place at HackMTL 2024.")
+
+    source = synthesize_profile_resume_source(
+        profile,
+        [doc_extracted, doc_raw],
+        [_ranked(doc_extracted, 0.8), _ranked(doc_raw, 0.6)],
+    )
+
+    # Structured extraction is present
+    assert "Senior engineer." in source.content
+    assert "## Summary" in source.content
+    # Raw content of unextracted doc is also present
+    assert "Won first place at HackMTL 2024." in source.content
+    # Whole-doc fallback header must NOT appear (we used extraction path)
+    assert "Profile documents:" not in source.content
+
+
+def test_mixed_mode_over_budget_unextracted_doc_is_noted():
+    """Unextracted docs that exceed remaining budget are noted but not silently dropped."""
+    profile = _make_profile()
+    ext = _extraction(summary=["x" * 10000])  # big extraction fills most of budget
+    doc_extracted = _make_doc(title="CV", metadata={"extraction": ext.model_dump()})
+    doc_raw = _make_doc(title="Big note", kind="note", content="y" * 5000)
+
+    source = synthesize_profile_resume_source(
+        profile,
+        [doc_extracted, doc_raw],
+        [_ranked(doc_extracted, 0.9), _ranked(doc_raw, 0.5)],
+    )
+
+    # The over-budget unextracted doc should be mentioned explicitly
+    assert "Big note" in source.content
+    # Content should not be silently dropped without acknowledgement
+    assert "omitted" in source.content or "y" * 100 in source.content
+
+
+# --- End-to-end: rank_profile_documents → synthesize_profile_resume_source ---
+
+@pytest.mark.asyncio
+async def test_e2e_all_selected_docs_survive_into_source():
+    """All selected documents must contribute content to the synthesized resume source.
+
+    This exercises the real rank_profile_documents → synthesize_profile_resume_source
+    pipeline with 5 docs (some extracted, some not) and verifies that each doc's
+    unique content appears in the output — no silent drops due to top_k cutoffs
+    or missing score_by_id entries.
+    """
+    profile = _make_profile()
+    job = JobPosting(
+        title="Senior Python Engineer",
+        company="Acme",
+        requirements=["Python", "AWS"],
+        keywords=["python", "aws"],
+        description="Build scalable cloud systems in Python.",
+    )
+
+    # Two docs with extraction data
+    ext_a = _extraction(
+        summary=["8 years Python at scale."],
+        experience=[ExperienceEntry(employer="Alpha", title="Lead", start="2018", end="Present", bullets=["UniqueAlphaBullet"])],
+    )
+    ext_b = _extraction(
+        skills=SkillsEntry(technical=["UniqueSkillBeta", "AWS"])
+    )
+    doc_a = _make_doc(title="Main CV", kind="resume", content="Python cloud work", metadata={"extraction": ext_a.model_dump()})
+    doc_b = _make_doc(title="Skills doc", kind="note", content="AWS skills", metadata={"extraction": ext_b.model_dump()})
+
+    # Three docs without extraction (raw text only)
+    doc_c = _make_doc(title="Hackathon", kind="note", content="UniqueHackathonContent won first place")
+    doc_d = _make_doc(title="Paper", kind="paper", content="UniqueResearchPaperAbstract on distributed systems")
+    doc_e = _make_doc(title="Side project", kind="other", content="UniqueProjectContent built in Rust")
+
+    all_docs = [doc_a, doc_b, doc_c, doc_d, doc_e]
+
+    # Mock vector scores (None = no embedding API), still get lexical/keyword scores
+    with patch("hr_breaker.services.profile_retrieval._vector_scores", return_value=[None] * 5):
+        ranked = await rank_profile_documents(all_docs, job)
+
+    # rank_profile_documents must return a score for every selected doc
+    assert len(ranked) == 5, "rank_profile_documents must score all selected docs"
+    ranked_ids = {r.document.id for r in ranked}
+    assert all(d.id in ranked_ids for d in all_docs), "every selected doc must appear in ranked list"
+
+    source = synthesize_profile_resume_source(profile, all_docs, ranked)
+
+    # Extracted content from doc_a and doc_b
+    assert "UniqueAlphaBullet" in source.content
+    assert "UniqueSkillBeta" in source.content
+
+    # Raw text from the three unextracted docs (or they are noted as over-budget)
+    for unique_marker, doc_title in [
+        ("UniqueHackathonContent", "Hackathon"),
+        ("UniqueResearchPaperAbstract", "Paper"),
+        ("UniqueProjectContent", "Side project"),
+    ]:
+        present = unique_marker in source.content
+        noted = doc_title in source.content  # mentioned in "omitted (over budget)" note
+        assert present or noted, f"Doc '{doc_title}' must appear in content or be explicitly noted as omitted"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,7 +1,7 @@
 """Tests for the renderer module."""
 
+import fitz
 import pytest
-
 from hr_breaker.models.resume_data import (
     ResumeData,
     RenderResult,
@@ -230,6 +230,7 @@ class TestHTMLRenderer:
         result = renderer.render_data(full_resume_data)
         # Just verify it renders - URL handling is in template
         assert len(result.pdf_bytes) > 0
+
 
 
 # --- Integration Tests ---

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -84,3 +84,12 @@ async def test_run_with_retry_retries_litellm_rate_limit():
     result = await run_with_retry(func, "arg1")
     assert result == "ok"
     assert func.call_count == 2
+
+
+def test_is_retryable_false_for_litellm_none_type_config_error():
+    exc = ModelHTTPError(
+        status_code=500,
+        model_name="openai/gpt-5.3-codex",
+        body="litellm.APIConnectionError: APIConnectionError: OpenAIException - argument of type 'NoneType' is not iterable",
+    )
+    assert is_retryable(exc) is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,12 +1,18 @@
 """Tests for FastAPI server endpoints."""
 
-import asyncio
+import json
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from pydantic_ai.exceptions import ModelHTTPError
 
-from hr_breaker.server import app, _cleanup_active
+import hr_breaker.config as config_module
+from hr_breaker.models.resume import ResumeSource
+from hr_breaker.server import app
+from hr_breaker.services.cache import ResumeCache
+from hr_breaker.services.profile_store import ProfileStore
 import hr_breaker.server as server_module
 
 
@@ -50,20 +56,97 @@ async def test_cached_resumes_empty(client):
 
 
 @pytest.mark.asyncio
+async def test_cached_resumes_include_profile_generated_entries_with_origin(client, tmp_path):
+    visible = ResumeSource(content="Pasted resume", first_name="Jane", filename="pasted", source_type="paste")
+    profile_resume = ResumeSource(
+        content="Profile: Candidate\n\nProfile-generated resume",
+        first_name="Jane",
+        source_type="profile",
+        source_profile_id="candidate",
+        source_profile_name="Candidate",
+    )
+    with patch("hr_breaker.services.cache.get_settings", return_value=MagicMock(cache_dir=tmp_path)):
+        ResumeCache().put(visible)
+        ResumeCache().put(profile_resume)
+        resp = await client.get("/api/resume/cached")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [item["source_type"] for item in data] == ["profile", "paste"]
+    assert data[0]["source_profile_id"] == "candidate"
+    assert data[0]["source_profile_name"] == "Candidate"
+    assert data[1]["filename"] == "pasted"
+
+@pytest.mark.asyncio
+async def test_resume_upload_applies_llm_overrides(client, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("FLASH_MODEL", raising=False)
+    monkeypatch.delenv("FLASH_OPENAI_API_BASE", raising=False)
+    config_module.clear_settings_cache()
+    try:
+        async def fake_extract_name(content):
+            assert content == "John Doe\nSoftware Engineer"
+            assert os.environ.get("OPENAI_API_KEY") == "sk-test"
+            assert os.environ.get("FLASH_MODEL") == "openai/gpt-5.3-codex"
+            assert os.environ.get("FLASH_OPENAI_API_BASE") == "https://example.test/v1"
+            return ("John", "Doe", "en")
+
+        with patch("hr_breaker.server.extract_name", new=AsyncMock(side_effect=fake_extract_name)):
+            resp = await client.post(
+                "/api/resume/upload",
+                files={"file": ("resume.txt", b"John Doe\nSoftware Engineer", "text/plain")},
+                data={
+                    "flash_model": "openai/gpt-5.3-codex",
+                    "reasoning_effort": "medium",
+                    "api_keys_json": json.dumps({"openai": "sk-test"}),
+                    "providers_json": json.dumps({
+                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                    }),
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["first_name"] == "John"
+    finally:
+        config_module.clear_settings_cache()
+
+@pytest.mark.asyncio
 async def test_paste_resume_empty(client):
     resp = await client.post("/api/resume/paste", json={"content": "  "})
     assert resp.status_code == 400
 
-
 @pytest.mark.asyncio
-async def test_paste_resume(client):
-    with patch("hr_breaker.server.extract_name", new_callable=AsyncMock, return_value=("John", "Doe", "en")):
-        resp = await client.post("/api/resume/paste", json={"content": "John Doe\nSoftware Engineer"})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["first_name"] == "John"
-    assert data["last_name"] == "Doe"
-    assert data["checksum"]
+async def test_paste_resume(client, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("FLASH_MODEL", raising=False)
+    monkeypatch.delenv("FLASH_OPENAI_API_BASE", raising=False)
+    config_module.clear_settings_cache()
+    try:
+        async def fake_extract_name(content):
+            assert content == "John Doe\nSoftware Engineer"
+            assert os.environ.get("OPENAI_API_KEY") == "sk-test"
+            assert os.environ.get("FLASH_MODEL") == "openai/gpt-5.3-codex"
+            assert os.environ.get("FLASH_OPENAI_API_BASE") == "https://example.test/v1"
+            return ("John", "Doe", "en")
+
+        with patch("hr_breaker.server.extract_name", new=AsyncMock(side_effect=fake_extract_name)):
+            resp = await client.post(
+                "/api/resume/paste",
+                json={
+                    "content": "John Doe\nSoftware Engineer",
+                    "flash_model": "openai/gpt-5.3-codex",
+                    "reasoning_effort": "medium",
+                    "api_keys": {"openai": "sk-test"},
+                    "providers": {
+                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                    },
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["first_name"] == "John"
+        assert data["last_name"] == "Doe"
+        assert data["checksum"]
+    finally:
+        config_module.clear_settings_cache()
 
 
 @pytest.mark.asyncio
@@ -128,3 +211,213 @@ async def test_stream_nonexistent(client):
 async def test_pdf_not_found(client):
     resp = await client.get("/api/pdf/nonexistent.pdf")
     assert resp.status_code == 404
+
+@pytest.mark.asyncio
+async def test_profile_document_upload_forwards_llm_overrides(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.submit") as mock_submit:
+            resp = await client.post(
+                f"/api/profile/{profile.id}/document",
+                files={"file": ("resume.txt", b"resume text", "text/plain")},
+                data={
+                    "flash_model": "openai/gpt-5.3-codex",
+                    "reasoning_effort": "medium",
+                    "api_keys_json": json.dumps({"openai": "sk-test"}),
+                    "providers_json": json.dumps({
+                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                    }),
+                },
+            )
+
+        assert resp.status_code == 200
+        doc_id = resp.json()["id"]
+        mock_submit.assert_called_once_with(
+            profile.id,
+            [doc_id],
+            overrides={
+                "flash_model": "openai/gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "api_keys": {"openai": "sk-test"},
+                "flash_openai_api_base": "https://example.test/v1",
+            },
+        )
+    finally:
+        config_module.clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_check_provider_forwards_request_and_returns_catalog(client):
+    expected = {
+        "status": {
+            "state": "connected",
+            "message": "Connected · 1 chat / 0 embedding",
+            "detail": "catalog loaded",
+        },
+        "chat_models": [{"value": "openai/gpt-4.1-mini", "label": "gpt-4.1-mini"}],
+        "embedding_models": [],
+    }
+
+    with patch(
+        "hr_breaker.services.llm_providers.fetch_provider_catalog",
+        new=AsyncMock(return_value=expected),
+    ) as mock_fetch:
+        resp = await client.post(
+            "/api/providers/check",
+            json={
+                "provider": "custom",
+                "api_key": "sk-test",
+                "base_url": "https://example.test/v1",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == expected
+    mock_fetch.assert_awaited_once_with(
+        provider="custom",
+        api_key="sk-test",
+        base_url="https://example.test/v1",
+    )
+
+@pytest.mark.asyncio
+async def test_re_extract_profile_forwards_llm_overrides(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        doc = store.add_note(profile.id, title="Resume", content_text="resume text")
+
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.submit") as mock_submit:
+            resp = await client.post(
+                f"/api/profile/{profile.id}/extract",
+                json={
+                    "flash_model": "openai/gpt-5.3-codex",
+                    "reasoning_effort": "medium",
+                    "api_keys": {"openai": "sk-test"},
+                    "providers": {
+                        "flash": {
+                            "provider": "custom",
+                            "base_url": "https://example.test/v1",
+                        },
+                    },
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"submitted": 1}
+        mock_submit.assert_called_once_with(
+            profile.id,
+            [doc.id],
+            overrides={
+                "flash_model": "openai/gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "api_keys": {"openai": "sk-test"},
+                "flash_openai_api_base": "https://example.test/v1",
+            },
+        )
+    finally:
+        config_module.clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        store.add_note(profile.id, title="Resume", content_text="resume text")
+
+        async def fake_rank_profile_documents(documents, job):
+            assert os.environ.get("OPENAI_API_KEY") == "sk-test"
+            assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == "https://example.test/v1"
+            assert os.environ.get("OPENAI_API_BASE") is None
+            return []
+
+        with patch(
+            "hr_breaker.services.profile_retrieval.rank_profile_documents",
+            new=AsyncMock(side_effect=fake_rank_profile_documents),
+        ), patch(
+            "hr_breaker.services.profile_retrieval.synthesize_profile_resume_source",
+            return_value=ResumeSource(content="profile resume", first_name="Jane", last_name="Doe"),
+        ):
+            resp = await client.post(
+                f"/api/profile/{profile.id}/synthesize",
+                json={
+                    "job_text": "Product manager role",
+                    "embedding_model": "openai/text-embedding-3-small",
+                    "api_keys": {"openai": "sk-test"},
+                    "providers": {
+                        "embedding": {
+                            "provider": "custom",
+                            "base_url": "https://example.test/v1",
+                        },
+                    },
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["first_name"] == "Jane"
+        assert resp.json()["last_name"] == "Doe"
+    finally:
+        config_module.clear_settings_cache()
+
+
+def test_build_overrides_maps_scoped_custom_base_urls():
+    req = server_module.OptimizeRequest(
+        resume_checksum="resume-checksum",
+        job_text="Product manager role",
+        flash_model="openai/gpt-5.3-codex",
+        embedding_model="openai/text-embedding-3-small",
+        api_keys={"openai": "sk-test"},
+        providers={
+            "flash": server_module.ProviderOverride(provider="custom", base_url="https://example.test/v1"),
+            "embedding": server_module.ProviderOverride(provider="custom", base_url="https://embed.example.test/v1"),
+        },
+        filter_thresholds={"vector": 0.5},
+    )
+
+    overrides = server_module._build_overrides(req)
+
+    assert overrides == {
+        "flash_model": "openai/gpt-5.3-codex",
+        "embedding_model": "openai/text-embedding-3-small",
+        "api_keys": {"openai": "sk-test"},
+        "flash_openai_api_base": "https://example.test/v1",
+        "embedding_openai_api_base": "https://embed.example.test/v1",
+        "filter_vector_threshold": 0.5,
+    }
+
+
+def test_normalize_optimization_error_for_custom_provider_none_type_failure():
+    req = server_module.OptimizeRequest(
+        resume_checksum="resume-checksum",
+        job_text="Product manager role",
+        pro_model="openai/gpt-5.4",
+        flash_model="openai/gpt-5.3-codex",
+        embedding_model="openai/text-embedding-3-small",
+        providers={
+            "flash": server_module.ProviderOverride(
+                provider="custom",
+                base_url="http://127.0.0.1:8317/v1",
+            ),
+        },
+    )
+    exc = ModelHTTPError(
+        status_code=500,
+        model_name="openai/gpt-5.3-codex",
+        body="litellm.APIConnectionError: APIConnectionError: OpenAIException - argument of type 'NoneType' is not iterable",
+    )
+
+    message = server_module._normalize_optimization_error(exc, req)
+
+    assert "Custom OpenAI-compatible provider request failed before the model returned a usable response" in message
+    assert "flash: http://127.0.0.1:8317/v1" in message
+    assert "openai/gpt-5.4, openai/gpt-5.3-codex, openai/text-embedding-3-small" in message

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -292,7 +292,7 @@ async def test_re_extract_profile_forwards_llm_overrides(client, monkeypatch, tm
         profile = store.create_profile("Candidate")
         doc = store.add_note(profile.id, title="Resume", content_text="resume text")
 
-        with patch("hr_breaker.services.extraction_worker.extraction_worker.submit") as mock_submit:
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.resubmit") as mock_resubmit:
             resp = await client.post(
                 f"/api/profile/{profile.id}/extract",
                 json={
@@ -310,7 +310,7 @@ async def test_re_extract_profile_forwards_llm_overrides(client, monkeypatch, tm
 
         assert resp.status_code == 200
         assert resp.json() == {"submitted": 1}
-        mock_submit.assert_called_once_with(
+        mock_resubmit.assert_called_once_with(
             profile.id,
             [doc.id],
             overrides={
@@ -325,6 +325,26 @@ async def test_re_extract_profile_forwards_llm_overrides(client, monkeypatch, tm
 
 
 @pytest.mark.asyncio
+async def test_delete_profile_document_cancels_worker_before_removal(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        doc = store.add_note(profile.id, title="Resume", content_text="resume text")
+
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.cancel") as mock_cancel:
+            resp = await client.delete(f"/api/profile/{profile.id}/document/{doc.id}")
+
+        assert resp.status_code == 200
+        mock_cancel.assert_called_once_with([doc.id])
+        assert store.get_document(profile.id, doc.id) is None
+    finally:
+        config_module.clear_settings_cache()
+
+
+
+@pytest.mark.asyncio
 async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp_path):
     monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -333,9 +353,16 @@ async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp
     try:
         store = ProfileStore()
         profile = store.create_profile("Candidate")
-        store.add_note(profile.id, title="Resume", content_text="resume text")
+        included_doc = store.add_note(profile.id, title="Resume", content_text="resume text")
+        skipped_doc = store.add_note(
+            profile.id,
+            title="Archive",
+            content_text="archived text",
+            included_by_default=False,
+        )
 
         async def fake_rank_profile_documents(documents, job):
+            assert [document.id for document in documents] == [included_doc.id]
             assert os.environ.get("OPENAI_API_KEY") == "sk-test"
             assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == "https://example.test/v1"
             assert os.environ.get("OPENAI_API_BASE") is None
@@ -352,6 +379,7 @@ async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp
                 f"/api/profile/{profile.id}/synthesize",
                 json={
                     "job_text": "Product manager role",
+                    "selected_doc_ids": [included_doc.id],
                     "embedding_model": "openai/text-embedding-3-small",
                     "api_keys": {"openai": "sk-test"},
                     "providers": {
@@ -366,6 +394,31 @@ async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp
         assert resp.status_code == 200
         assert resp.json()["first_name"] == "Jane"
         assert resp.json()["last_name"] == "Doe"
+        assert skipped_doc.id != included_doc.id
+    finally:
+        config_module.clear_settings_cache()
+
+
+
+@pytest.mark.asyncio
+async def test_synthesize_profile_rejects_unknown_selected_doc_ids(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        store.add_note(profile.id, title="Resume", content_text="resume text")
+
+        resp = await client.post(
+            f"/api/profile/{profile.id}/synthesize",
+            json={
+                "job_text": "Product manager role",
+                "selected_doc_ids": ["missing-doc"],
+            },
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "Unknown profile documents in synthesis scope"
     finally:
         config_module.clear_settings_cache()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -109,6 +109,20 @@ async def test_resume_upload_applies_llm_overrides(client, monkeypatch):
         config_module.clear_settings_cache()
 
 @pytest.mark.asyncio
+async def test_resume_upload_rejects_malformed_override_json(client):
+    resp = await client.post(
+        "/api/resume/upload",
+        files={"file": ("resume.txt", b"John Doe\nSoftware Engineer", "text/plain")},
+        data={
+            "api_keys_json": "{not-json}",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "Invalid api_keys_json" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
 async def test_paste_resume_empty(client):
     resp = await client.post("/api/resume/paste", json={"content": "  "})
     assert resp.status_code == 400
@@ -211,6 +225,26 @@ async def test_stream_nonexistent(client):
 async def test_pdf_not_found(client):
     resp = await client.get("/api/pdf/nonexistent.pdf")
     assert resp.status_code == 404
+
+@pytest.mark.asyncio
+async def test_profile_document_upload_rejects_malformed_override_json(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+
+        resp = await client.post(
+            f"/api/profile/{profile.id}/document",
+            files={"file": ("resume.txt", b"resume text", "text/plain")},
+            data={"providers_json": "{not-json}"},
+        )
+
+        assert resp.status_code == 400
+        assert "Invalid providers_json" in resp.json()["error"]
+    finally:
+        config_module.clear_settings_cache()
+
 
 @pytest.mark.asyncio
 async def test_profile_document_upload_forwards_llm_overrides(client, monkeypatch, tmp_path):

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -91,6 +91,8 @@ def source_resume():
     return ResumeSource(content="John Doe\nPython developer with 5 years experience")
 
 
+
+
 # ── Orchestration optimize_for_job translation integration ────────────────────
 
 
@@ -234,4 +236,4 @@ class TestTranslationConfig:
     def test_default_language_setting(self):
         from hr_breaker.config import Settings
         s = Settings()
-        assert s.default_language == "from_job"
+        assert s.default_language == "en"

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -233,7 +233,9 @@ class TestPDFStorageLanguagePostfix:
 
 
 class TestTranslationConfig:
-    def test_default_language_setting(self):
-        from hr_breaker.config import Settings
+    def test_default_language_setting(self, monkeypatch):
+        monkeypatch.delenv("DEFAULT_LANGUAGE", raising=False)
+        from hr_breaker.config import Settings, get_settings
+        get_settings.cache_clear()
         s = Settings()
-        assert s.default_language == "en"
+        assert s.default_language == "from_job"

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.76.0"
+version = "0.86.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -160,9 +160,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/be/d11abafaa15d6304826438170f7574d750218f49a106c54424a40cef4494/anthropic-0.76.0.tar.gz", hash = "sha256:e0cae6a368986d5cf6df743dfbb1b9519e6a9eee9c6c942ad8121c0b34416ffe", size = 495483, upload-time = "2026-01-13T18:41:14.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/70/7b0fd9c1a738f59d3babe2b4212031c34ab7d0fda4ffef15b58a55c5bcea/anthropic-0.76.0-py3-none-any.whl", hash = "sha256:81efa3113901192af2f0fe977d3ec73fdadb1e691586306c4256cd6d5ccc331c", size = 390309, upload-time = "2026-01-13T18:41:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "cohere"
-version = "5.20.2"
+version = "5.20.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastavro" },
@@ -540,9 +540,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/52/08564d1820970010d30421cd6e36f2e4ca552646504d3fe532eef282c88d/cohere-5.20.2.tar.gz", hash = "sha256:0aa9f3735626b70eedf15c231c61f3a58e7f8bbe5f0509fe7b2e6606c5d420f1", size = 180820, upload-time = "2026-01-23T13:42:51.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/0b/96e2b55a0114ed9d69b3154565f54b764e7530735426290b000f467f4c0f/cohere-5.20.7.tar.gz", hash = "sha256:997ed85fabb3a1e4a4c036fdb520382e7bfa670db48eb59a026803b6f7061dbb", size = 184986, upload-time = "2026-02-25T01:22:18.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/10/d76f045eefe42fb3f4e271d17ab41b5e73a3b6de69c98e15ab1cb0c8e6f6/cohere-5.20.2-py3-none-any.whl", hash = "sha256:26156d83bf3e3e4475e4caa1d8c4148475c5b0a253aee6066d83c643e9045be6", size = 318986, upload-time = "2026-01-23T13:42:50.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/86/dc991a75e3b9c2007b90dbfaf7f36fdb2457c216f799e26ce0474faf0c1f/cohere-5.20.7-py3-none-any.whl", hash = "sha256:043fef2a12c30c07e9b2c1f0b869fd66ffd911f58d1492f87e901c4190a65914", size = 323389, upload-time = "2026-02-25T01:22:16.902Z" },
 ]
 
 [[package]]
@@ -1135,15 +1135,11 @@ wheels = [
 ]
 
 [[package]]
-name = "griffe"
-version = "1.15.0"
+name = "griffelib"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
 
 [[package]]
@@ -1225,24 +1221,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/e8cf74c3c48e5485c7acc5a990d0d8516cdfb5fdf80f799174f1287cc1b5/hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4", size = 3796125, upload-time = "2026-03-13T06:58:33.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d4/b73ebab01cbf60777323b7de9ef05550790451eb5172a220d6b9845385ec/hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81", size = 3555985, upload-time = "2026-03-13T06:58:31.797Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e7/ded6d1bd041c3f2bca9e913a0091adfe32371988e047dd3a68a2463c15a2/hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6", size = 4212085, upload-time = "2026-03-13T06:58:24.323Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c1/a0a44d1f98934f7bdf17f7a915b934f9fca44bb826628c553589900f6df8/hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555", size = 3988266, upload-time = "2026-03-13T06:58:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/82/be713b439060e7d1f1d93543c8053d4ef2fe7e6922c5b31642eaa26f3c4b/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496", size = 4188513, upload-time = "2026-03-13T06:58:40.858Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/cbd4188b22abd80ebd0edbb2b3e87f2633e958983519980815fb8314eae5/hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d", size = 4428287, upload-time = "2026-03-13T06:58:42.601Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4e/84e45b25e2e3e903ed3db68d7eafa96dae9a1d1f6d0e7fc85120347a852f/hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0", size = 3665574, upload-time = "2026-03-13T06:58:53.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/71/c5ac2b9a7ae39c14e91973035286e73911c31980fe44e7b1d03730c00adc/hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82", size = 3528760, upload-time = "2026-03-13T06:58:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
+    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
 ]
 
 [[package]]
@@ -1385,26 +1383,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a8/94ccc0aec97b996a3a68f3e1fa06a4bd7185dd02bf22bfba794a0ade8440/huggingface_hub-1.7.1.tar.gz", hash = "sha256:be38fe66e9b03c027ad755cb9e4b87ff0303c98acf515b5d579690beb0bf3048", size = 722097, upload-time = "2026-03-13T09:36:07.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
-]
-
-[package.optional-dependencies]
-inference = [
-    { name = "aiohttp" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/ca21955d6117a394a482c7862ce96216239d0e3a53133ae8510727a8bcfa/huggingface_hub-1.7.1-py3-none-any.whl", hash = "sha256:38c6cce7419bbde8caac26a45ed22b0cea24152a8961565d70ec21f88752bfaa", size = 616308, upload-time = "2026-03-13T09:36:06.062Z" },
 ]
 
 [[package]]
@@ -1664,7 +1658,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.81.9"
+version = "1.82.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1680,9 +1674,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/8f/2a08f3d86fd008b4b02254649883032068378a8551baed93e8d9dcbbdb5d/litellm-1.81.9.tar.gz", hash = "sha256:a2cd9bc53a88696c21309ef37c55556f03c501392ed59d7f4250f9932917c13c", size = 16276983, upload-time = "2026-02-07T21:14:24.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/79/b492be13542aebd62aafc0490e4d5d6e8e00ce54240bcabf5c3e46b1a49b/litellm-1.82.4.tar.gz", hash = "sha256:9c52b1c0762cb0593cdc97b26a8e05004e19b03f394ccd0f42fac82eff0d4980", size = 17378196, upload-time = "2026-03-18T01:18:05.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/672fc06c8a2803477e61e0de383d3c6e686e0f0fc62789c21f0317494076/litellm-1.81.9-py3-none-any.whl", hash = "sha256:24ee273bc8a62299fbb754035f83fb7d8d44329c383701a2bd034f4fd1c19084", size = 14433170, upload-time = "2026-02-07T21:14:21.469Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ad/7eaa1121c6b191f2f5f2e8c7379823ece6ec83741a4b3c81b82fe2832401/litellm-1.82.4-py3-none-any.whl", hash = "sha256:d37c34a847e7952a146ed0e2888a24d3edec7787955c6826337395e755ad5c4b", size = 15559801, upload-time = "2026-03-18T01:18:02.026Z" },
 ]
 
 [[package]]
@@ -2150,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.16.0"
+version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2162,9 +2156,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/6c/e4c964fcf1d527fdf4739e7cc940c60075a4114d50d03871d5d5b1e13a88/openai-2.16.0.tar.gz", hash = "sha256:42eaa22ca0d8ded4367a77374104d7a2feafee5bd60a107c3c11b5243a11cd12", size = 629649, upload-time = "2026-01-27T23:28:02.579Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/15/203d537e58986b5673e7f232453a2a2f110f22757b15921cbdeea392e520/openai-2.29.0.tar.gz", hash = "sha256:32d09eb2f661b38d3edd7d7e1a2943d1633f572596febe64c0cd370c86d52bec", size = 671128, upload-time = "2026-03-17T17:53:49.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/83/0315bf2cfd75a2ce8a7e54188e9456c60cec6c0cf66728ed07bd9859ff26/openai-2.16.0-py3-none-any.whl", hash = "sha256:5f46643a8f42899a84e80c38838135d7038e7718333ce61396994f887b09a59b", size = 1068612, upload-time = "2026-01-27T23:28:00.356Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/35b6f9c8cf9318e3dbb7146cc82dab4cf61182a8d5406fc9b50864362895/openai-2.29.0-py3-none-any.whl", hash = "sha256:b7c5de513c3286d17c5e29b92c4c98ceaf0d775244ac8159aeb1bddf840eb42a", size = 1141533, upload-time = "2026-03-17T17:53:47.348Z" },
 ]
 
 [[package]]
@@ -2664,14 +2658,14 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.48.0"
+version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/30/913d8d3f5271289c1753d0970751143c47acf762d00b11756b25e3e5db34/pydantic_ai-1.48.0.tar.gz", hash = "sha256:d739d7a56125f58a9a8dfbdbb737cb082f9304802f9886ada4195ff76883b15c", size = 11795, upload-time = "2026-01-28T00:09:30.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/98/87c97dce65711f922ac448f9103a0bf7c59be67af6663450a8bee3dc824a/pydantic_ai-1.70.0.tar.gz", hash = "sha256:f06368a4fa91f6abcc11d73524dc81516b63739bd88ac93b330e16708b6f784b", size = 12297, upload-time = "2026-03-18T04:24:32.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/ce/dd0dbaa03f2166e895ef4af74f46780b68c96f17538a0bc28edff2196748/pydantic_ai-1.48.0-py3-none-any.whl", hash = "sha256:da7eacfee0b9534f03ff50d96a66406f7030df59e2626b0100618c0d208b2503", size = 7220, upload-time = "2026-01-28T00:09:20.729Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/3a49448850ecdbc020ffa9fde9b7e4f6986c4d67488da33c17bc2150616c/pydantic_ai-1.70.0-py3-none-any.whl", hash = "sha256:d2dbac707153fcdd890e48fc31c4235b4f5f15c815fb60438b76085ffcd0205f", size = 7227, upload-time = "2026-03-18T04:24:24.543Z" },
 ]
 
 [[package]]
@@ -2689,21 +2683,21 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.48.0"
+version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
-    { name = "griffe" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/e1/02d712bb1e93ccd4cf08e154811914da406320cf2ce041941992b642f675/pydantic_ai_slim-1.48.0.tar.gz", hash = "sha256:b386dc9fb6f751aac12599b0efdd3f82ca0c9ec9ae67323bc343d1b4f5f1e7eb", size = 396949, upload-time = "2026-01-28T00:09:33.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/97/d57ee44976c349658ea7c645c5c2e1a26830e4b60fdeeee2669d4aaef6eb/pydantic_ai_slim-1.70.0.tar.gz", hash = "sha256:3df0c0e92f72c35e546d24795bce1f4d38f81da2d10addd2e9f255b2d2c83c91", size = 445474, upload-time = "2026-03-18T04:24:34.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/77/42872ccfd21bb8fc701fbe5715ec476de521200284527d04981d32e88389/pydantic_ai_slim-1.48.0-py3-none-any.whl", hash = "sha256:23aa473115f7402876cff448d87ae411dace9c78457640e395f9878882ec2f00", size = 519241, upload-time = "2026-01-28T00:09:24.215Z" },
+    { url = "https://files.pythonhosted.org/packages/da/8c/8545d28d0b3a9957aa21393cfdab8280bb854362360b296cd486ed1713ec/pydantic_ai_slim-1.70.0-py3-none-any.whl", hash = "sha256:162907092a562b3160d9ef0418d317ec941c5c0e6dd6e0aa0dbb53b5a5cd3450", size = 576244, upload-time = "2026-03-18T04:24:27.301Z" },
 ]
 
 [package.optional-dependencies]
@@ -2739,7 +2733,7 @@ groq = [
     { name = "groq" },
 ]
 huggingface = [
-    { name = "huggingface-hub", extra = ["inference"] },
+    { name = "huggingface-hub" },
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
@@ -2863,7 +2857,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.48.0"
+version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2873,14 +2867,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/a1/50e031c1d11613cb4864d885a2e9ca87ad397b132a570c77b7c4cd2054f3/pydantic_evals-1.48.0.tar.gz", hash = "sha256:cc0d7a2178fcae8696df56a8ed7b44b8eb80991d492b608a83d3dfa80d8e0f35", size = 47191, upload-time = "2026-01-28T00:09:34.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/46/21ab46e81cba78892c92ab71d21b61b23682e5e5fc645aa3647822abc3a5/pydantic_evals-1.70.0.tar.gz", hash = "sha256:ac42099233557344b41f6c43429294e61202490eb0ee9ebf6422dd4c7ea6d941", size = 56737, upload-time = "2026-03-18T04:24:35.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/48/f210b0c3b0600e47295c10e532eaa97e0bde4ed5f9c84a5cd87a9401a069/pydantic_evals-1.48.0-py3-none-any.whl", hash = "sha256:cf7982038407f7d905d95a8c9f693b37dfb515024d63f28013e400100d00c5de", size = 56378, upload-time = "2026-01-28T00:09:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9a/6d5b74b602820621bb225e47d47f514d72e5ac5119e5dd740cd493e8ffa7/pydantic_evals-1.70.0-py3-none-any.whl", hash = "sha256:2f0c3c045c8c07b3d13876b8b0a64063ef14eb9ce27331694c8c1275f9c234b1", size = 67604, upload-time = "2026-03-18T04:24:29.134Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.48.0"
+version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2888,9 +2882,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/da/ed69a409ff559e1088607b5f65b667edbee0dd0169582c013221bfed4711/pydantic_graph-1.48.0.tar.gz", hash = "sha256:de731137208a80dbf1396f23954e7f920da4b8b9d74d02e5cdb154d01fb878c5", size = 58458, upload-time = "2026-01-28T00:09:36.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/27/f7a71ca2a3705e7c24fd777959cf5515646cc5f23b5b16c886a2ed373340/pydantic_graph-1.70.0.tar.gz", hash = "sha256:3f76d9137369ef8748b0e8a6df1a08262118af20a32bc139d23e5c0509c6b711", size = 58578, upload-time = "2026-03-18T04:24:37.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/7f/9db05557d9fdb01e888ce5c18875346868b68d94ab600154d74a34279eca/pydantic_graph-1.48.0-py3-none-any.whl", hash = "sha256:47557ffca1972a8cfb1de0c427bf4eba0a080dbd53e966a94e88b55529442485", size = 72345, upload-time = "2026-01-28T00:09:28.15Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fd/19c42b60c37dfdbbf5b76c7b218e8309b43dac501f7aaf2025527ca05023/pydantic_graph-1.70.0-py3-none-any.whl", hash = "sha256:6083c1503a2587990ee1b8a15915106e3ddabc8f3f11fbc4a108a7d7496af4a5", size = 72351, upload-time = "2026-03-18T04:24:30.291Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Continued from: https://github.com/btseytlin/hr-breaker/pull/28

## Summary
- Profiles become the primary concept in the Resume card — no more tabs
- `POST /api/profile/quick-create` endpoint creates profile + caches resume in one call
- Inline profile editor with extraction badges, doc selection, add note
- Legacy non-profile resumes shown in "Previous uploads" section
- Extraction worker auto-updates profile name from extracted content
- Selected resume persisted to localStorage across page refreshes

## Changes
- `server.py` — new quick-create endpoint, `updated_at` in profile list
- `extraction_worker.py` — `_maybe_update_profile_name()` after extraction
- `index.html` — rewritten Resume card (flat profile list, inline editor, drop zone)
- `app.js` — `editingId` replaces `selected`, `pasteMode` replaces `inputMode`, new computeds
- `style.css` — extraction badges, doc count badges, inline editor, help hint

## Test plan
- [x] `uv run pytest tests/ -x` — 257 passed
- [x] Quick-create via API with pasted content works
- [x] Profile list returns `updated_at`
- [ ] Browser: drop file → creates profile + loads resume
- [ ] Browser: paste text → creates profile + loads resume
- [ ] Browser: click profile → auto-synthesizes resume
- [ ] Browser: click ✎ → inline editor, manage docs
- [ ] Browser: refresh preserves selected resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)