### PR TITLE
feat: editable notes, selective extraction, shared LLM provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,10 +152,11 @@ Repro: `uv run python scripts/repro_vision_bug.py` (without patch) vs `uv run py
   - Legacy cached resumes (non-profile `source_type`) shown in separate "Previous uploads" section below profiles
   - Drop zone and paste toggle below profile list for quick profile creation
 - Per-run overrides: frontend sends model/key/threshold overrides with optimize request
+- Custom endpoints use canonical LiteLLM model prefixes (`openai/...`, `anthropic/...`) plus a per-scope `Use custom base URL` toggle. Chat scopes support custom base URLs for canonical OpenAI/Anthropic routes; embedding custom base URLs are limited to canonical `openai/...` models.
 - Backend: `settings_override()` context manager temporarily sets env vars + clears `get_settings` cache for the duration of a run (safe since only one optimization runs at a time)
 - API keys: never persisted to localStorage, only sent per-request. Backend only returns boolean "is set" status, never actual values
 - Settings (models, thresholds, reasoning effort) prefilled from server defaults on load
-- Only settings, drawer state, and selected resume checksum persisted to localStorage (no job text, no API keys)
+- localStorage persists settings, drawer state, selected resume checksum, and custom base URL toggle/value state. API keys and job text are not persisted.
 
 ### Language Mode System
 - Language is a **mode**, not a fixed code: `from_job` (default), `from_resume`, `en`, `ru`

--- a/src/hr_breaker/config.py
+++ b/src/hr_breaker/config.py
@@ -104,6 +104,18 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("FLASH_ANTHROPIC_API_BASE"),
     )
+    llm_shared_provider: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LLM_SHARED_PROVIDER"),
+    )
+    llm_shared_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LLM_SHARED_API_KEY"),
+    )
+    llm_shared_base_url: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LLM_SHARED_BASE_URL"),
+    )
 
     pro_model: str = "gemini/gemini-3-pro-preview"
     flash_model: str = "gemini/gemini-3-flash-preview"
@@ -187,6 +199,11 @@ class Settings(BaseSettings):
             os.environ["PRO_ANTHROPIC_API_BASE"] = self.pro_anthropic_api_base
         if self.flash_anthropic_api_base and "FLASH_ANTHROPIC_API_BASE" not in os.environ:
             os.environ["FLASH_ANTHROPIC_API_BASE"] = self.flash_anthropic_api_base
+        if self.llm_shared_provider == "openai_compatible":
+            if self.llm_shared_api_key and not os.environ.get("OPENAI_API_KEY"):
+                os.environ["OPENAI_API_KEY"] = sanitize_api_key(self.llm_shared_api_key, "openai")
+            if self.llm_shared_base_url and not os.environ.get("OPENAI_API_BASE"):
+                os.environ["OPENAI_API_BASE"] = self.llm_shared_base_url
 
 
 @lru_cache
@@ -276,7 +293,10 @@ def _litellm_api_base_for_model(scope: str, model_name: str) -> str | None:
         return None
     scoped_field, default_field = field_names
     settings = get_settings()
-    return getattr(settings, scoped_field) or getattr(settings, default_field)
+    api_base = getattr(settings, scoped_field) or getattr(settings, default_field)
+    if not api_base and provider == "openai" and settings.llm_shared_provider == "openai_compatible":
+        return settings.llm_shared_base_url
+    return api_base
 
 
 def _litellm_model(scope: str, model_name: str) -> LiteLLMModel:

--- a/src/hr_breaker/config.py
+++ b/src/hr_breaker/config.py
@@ -58,6 +58,10 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("OPENAI_API_BASE", "OPENAI_BASE_URL"),
     )
+    anthropic_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("ANTHROPIC_API_BASE", "ANTHROPIC_BASE_URL"),
+    )
     pro_openai_api_base: str | None = Field(
         default=None,
         validation_alias=AliasChoices("PRO_OPENAI_API_BASE"),
@@ -69,6 +73,14 @@ class Settings(BaseSettings):
     embedding_openai_api_base: str | None = Field(
         default=None,
         validation_alias=AliasChoices("EMBEDDING_OPENAI_API_BASE"),
+    )
+    pro_anthropic_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("PRO_ANTHROPIC_API_BASE"),
+    )
+    flash_anthropic_api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("FLASH_ANTHROPIC_API_BASE"),
     )
 
     pro_model: str = "gemini/gemini-3-pro-preview"
@@ -136,12 +148,18 @@ class Settings(BaseSettings):
             os.environ["MOONSHOT_API_KEY"] = self.moonshot_api_key
         if self.openai_api_base and "OPENAI_API_BASE" not in os.environ:
             os.environ["OPENAI_API_BASE"] = self.openai_api_base
+        if self.anthropic_api_base and "ANTHROPIC_API_BASE" not in os.environ:
+            os.environ["ANTHROPIC_API_BASE"] = self.anthropic_api_base
         if self.pro_openai_api_base and "PRO_OPENAI_API_BASE" not in os.environ:
             os.environ["PRO_OPENAI_API_BASE"] = self.pro_openai_api_base
         if self.flash_openai_api_base and "FLASH_OPENAI_API_BASE" not in os.environ:
             os.environ["FLASH_OPENAI_API_BASE"] = self.flash_openai_api_base
         if self.embedding_openai_api_base and "EMBEDDING_OPENAI_API_BASE" not in os.environ:
             os.environ["EMBEDDING_OPENAI_API_BASE"] = self.embedding_openai_api_base
+        if self.pro_anthropic_api_base and "PRO_ANTHROPIC_API_BASE" not in os.environ:
+            os.environ["PRO_ANTHROPIC_API_BASE"] = self.pro_anthropic_api_base
+        if self.flash_anthropic_api_base and "FLASH_ANTHROPIC_API_BASE" not in os.environ:
+            os.environ["FLASH_ANTHROPIC_API_BASE"] = self.flash_anthropic_api_base
 
 
 @lru_cache
@@ -154,18 +172,31 @@ def clear_settings_cache() -> None:
     get_settings.cache_clear()
 
 
-def required_api_key_env_for_model(model_name: str) -> str | None:
+def model_provider_family(model_name: str) -> str | None:
+    if not model_name:
+        return None
     if model_name.startswith("openrouter/"):
-        return "OPENROUTER_API_KEY"
+        return "openrouter"
     if model_name.startswith("gemini/") or "gemini" in model_name:
-        return "GEMINI_API_KEY"
-    if model_name.startswith("openai/"):
-        return "OPENAI_API_KEY"
-    if model_name.startswith("anthropic/"):
-        return "ANTHROPIC_API_KEY"
-    if model_name.startswith("moonshot/"):
-        return "MOONSHOT_API_KEY"
+        return "gemini"
+    prefix = model_name.split("/", 1)[0]
+    if prefix in {"openai", "anthropic", "moonshot"}:
+        return prefix
     return None
+
+
+def required_api_key_env_for_model(model_name: str) -> str | None:
+    provider = model_provider_family(model_name)
+    if provider is None:
+        return None
+    env_map = {
+        "openrouter": "OPENROUTER_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "moonshot": "MOONSHOT_API_KEY",
+    }
+    return env_map.get(provider)
 
 
 def has_api_key_for_model(model_name: str) -> bool:
@@ -184,16 +215,41 @@ def has_api_key_for_model(model_name: str) -> bool:
     )
 
 
-def _litellm_api_base_for_model(scope: str, model_name: str) -> str | None:
-    settings = get_settings()
-    if not model_name.startswith("openai/"):
+_CUSTOM_API_BASE_FIELD_MAP: dict[str, dict[str, tuple[str, str]]] = {
+    "pro": {
+        "openai": ("pro_openai_api_base", "openai_api_base"),
+        "anthropic": ("pro_anthropic_api_base", "anthropic_api_base"),
+    },
+    "flash": {
+        "openai": ("flash_openai_api_base", "openai_api_base"),
+        "anthropic": ("flash_anthropic_api_base", "anthropic_api_base"),
+    },
+    "embedding": {
+        "openai": ("embedding_openai_api_base", "openai_api_base"),
+    },
+}
+
+
+def custom_api_base_settings_field(scope: str, model_name: str) -> str | None:
+    provider = model_provider_family(model_name)
+    if provider is None:
         return None
-    scoped_field = {
-        "pro": "pro_openai_api_base",
-        "flash": "flash_openai_api_base",
-        "embedding": "embedding_openai_api_base",
-    }[scope]
-    return getattr(settings, scoped_field) or settings.openai_api_base
+    field_names = _CUSTOM_API_BASE_FIELD_MAP.get(scope, {}).get(provider)
+    if field_names is None:
+        return None
+    return field_names[0]
+
+
+def _litellm_api_base_for_model(scope: str, model_name: str) -> str | None:
+    provider = model_provider_family(model_name)
+    if provider is None:
+        return None
+    field_names = _CUSTOM_API_BASE_FIELD_MAP.get(scope, {}).get(provider)
+    if field_names is None:
+        return None
+    scoped_field, default_field = field_names
+    settings = get_settings()
+    return getattr(settings, scoped_field) or getattr(settings, default_field)
 
 
 def _litellm_model(scope: str, model_name: str) -> LiteLLMModel:
@@ -212,16 +268,18 @@ def get_embedding_api_base() -> str | None:
     settings = get_settings()
     return _litellm_api_base_for_model("embedding", settings.embedding_model)
 
-
 _FIELD_ENV_MAP = {
     "pro_model": "PRO_MODEL",
     "flash_model": "FLASH_MODEL",
     "embedding_model": "EMBEDDING_MODEL",
     "reasoning_effort": "REASONING_EFFORT",
     "openai_api_base": "OPENAI_API_BASE",
+    "anthropic_api_base": "ANTHROPIC_API_BASE",
     "pro_openai_api_base": "PRO_OPENAI_API_BASE",
     "flash_openai_api_base": "FLASH_OPENAI_API_BASE",
     "embedding_openai_api_base": "EMBEDDING_OPENAI_API_BASE",
+    "pro_anthropic_api_base": "PRO_ANTHROPIC_API_BASE",
+    "flash_anthropic_api_base": "FLASH_ANTHROPIC_API_BASE",
     "filter_hallucination_threshold": "FILTER_HALLUCINATION_THRESHOLD",
     "filter_keyword_threshold": "FILTER_KEYWORD_THRESHOLD",
     "filter_llm_threshold": "FILTER_LLM_THRESHOLD",

--- a/src/hr_breaker/server.py
+++ b/src/hr_breaker/server.py
@@ -128,7 +128,7 @@ class CreateProfileRequest(BaseModel):
 
 
 class ProfileActionRequest(LLMOverrideRequest):
-    pass
+    doc_ids: list[str] | None = None
 
 
 class SynthesizeProfileRequest(ProfileActionRequest):
@@ -137,6 +137,11 @@ class SynthesizeProfileRequest(ProfileActionRequest):
 
 
 class AddNoteRequest(BaseModel):
+    title: str
+    content: str
+
+
+class UpdateNoteRequest(BaseModel):
     title: str
     content: str
 
@@ -489,6 +494,7 @@ async def get_profile(profile_id: str):
             "id": d.id,
             "title": d.title,
             "kind": d.kind,
+            "content": d.content_text if d.kind == "note" else None,
             "included_by_default": d.included_by_default,
             "extraction_status": d.metadata.get("extraction_status", "pending"),
         }
@@ -562,6 +568,29 @@ async def add_profile_note(profile_id: str, req: AddNoteRequest):
     return {"id": doc.id, "title": doc.title, "kind": doc.kind}
 
 
+@app.patch("/api/profile/{profile_id}/note/{doc_id}")
+async def update_profile_note(profile_id: str, doc_id: str, req: UpdateNoteRequest):
+    from hr_breaker.services.profile_store import ProfileStore
+    from hr_breaker.services.extraction_worker import extraction_worker
+    store = ProfileStore()
+    doc = store.get_document(profile_id, doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if doc.kind != "note":
+        raise HTTPException(status_code=400, detail="Only notes can be edited")
+    if not req.title.strip():
+        raise HTTPException(status_code=400, detail="Note title is required")
+
+    if req.title.strip() == doc.title and req.content.strip() == (doc.content_text or ""):
+        return {"id": doc.id, "title": doc.title, "kind": doc.kind, "content": doc.content_text}
+    extraction_worker.cancel([doc_id])
+    updated = store.update_note(profile_id, doc_id, title=req.title.strip(), content_text=req.content.strip())
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    extraction_worker.submit(profile_id, [updated.id])
+    return {"id": updated.id, "title": updated.title, "kind": updated.kind, "content": updated.content_text}
+
+
 @app.get("/api/profile/{profile_id}/extraction-status")
 async def profile_extraction_status(profile_id: str):
     from hr_breaker.services.profile_store import ProfileStore
@@ -589,7 +618,13 @@ async def re_extract_profile(profile_id: str, req: ProfileActionRequest | None =
     if not store.get_profile(profile_id):
         raise HTTPException(status_code=404, detail="Profile not found")
     documents = store.list_documents(profile_id)
-    doc_ids = [d.id for d in documents]
+    all_doc_ids = [d.id for d in documents]
+    requested = (req or ProfileActionRequest()).doc_ids
+    doc_ids = [did for did in requested if did in set(all_doc_ids)] if requested else all_doc_ids
+    if not doc_ids:
+        return JSONResponse(status_code=400, content={"error": "No matching documents to extract"})
+
+
     try:
         overrides = _build_overrides(req or ProfileActionRequest())
     except ValueError as exc:

--- a/src/hr_breaker/server.py
+++ b/src/hr_breaker/server.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from pydantic_ai.exceptions import ModelHTTPError
 
 from hr_breaker.agents import extract_name, parse_job_posting
-from hr_breaker.config import get_settings, logger, settings_override
+from hr_breaker.config import custom_api_base_settings_field, get_settings, logger, settings_override
 from hr_breaker.models import (
     GeneratedPDF,
     ResumeSource,
@@ -222,6 +222,8 @@ async def paste_resume(req: PasteResumeRequest):
     try:
         with settings_override(_build_overrides(req)):
             first_name, last_name, language_code = await extract_name(content)
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": f"Failed to extract name: {e}"})
 
@@ -584,7 +586,10 @@ async def re_extract_profile(profile_id: str, req: ProfileActionRequest | None =
         raise HTTPException(status_code=404, detail="Profile not found")
     documents = store.list_documents(profile_id)
     doc_ids = [d.id for d in documents]
-    overrides = _build_overrides(req or ProfileActionRequest())
+    try:
+        overrides = _build_overrides(req or ProfileActionRequest())
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
     extraction_worker.resubmit(profile_id, doc_ids, overrides=overrides or None)
     return {"submitted": len(doc_ids)}
 
@@ -612,7 +617,10 @@ async def synthesize_profile(profile_id: str, req: SynthesizeProfileRequest):
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"error": str(exc)})
 
-    overrides = _build_overrides(req)
+    try:
+        overrides = _build_overrides(req)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
     try:
         with settings_override(overrides):
             job_text = req.job_text or ""
@@ -670,12 +678,17 @@ async def optimize_endpoint(req: OptimizeRequest):
     if not source:
         return JSONResponse(status_code=400, content={"error": "Resume not found. Upload or paste first."})
 
+    try:
+        overrides = _build_overrides(req)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+
     opt_id = str(uuid.uuid4())
     events: list[str] = []
 
     _active_optimization = {"id": opt_id, "task": None, "events": events, "subscribers": []}
 
-    task = asyncio.create_task(_run_optimization(req, source))
+    task = asyncio.create_task(_run_optimization(req, source, overrides))
     _active_optimization["task"] = task
 
     # Return SSE stream (first event is 'started' with the id)
@@ -787,6 +800,68 @@ def _selected_custom_provider_bases(req: OptimizeRequest) -> list[str]:
     return selected
 
 
+_MODEL_FIELD_BY_SCOPE = {
+    "pro": "pro_model",
+    "flash": "flash_model",
+    "embedding": "embedding_model",
+}
+
+_CANONICAL_CUSTOM_BASE_PROVIDERS = {"openai", "anthropic"}
+
+
+def _custom_base_url_usage_hint(provider: str) -> str:
+    if provider == "anthropic":
+        return "Use `anthropic/<model>` and set the Base URL separately for Anthropic-compatible endpoints."
+    return "Use `openai/<model>` and set the Base URL separately for OpenAI-compatible endpoints."
+
+
+def _unsupported_custom_base_url_message(scope: str) -> str:
+    if scope == "embedding":
+        return (
+            "Custom base URL is supported only for `openai/<model>` embeddings. "
+            "Use `openai/<model>` or disable the custom base URL for embeddings."
+        )
+    return (
+        f"Custom base URL is supported only for `openai/<model>` or `anthropic/<model>` {scope} models. "
+        f"Update the {scope} model path or disable the custom base URL."
+    )
+
+
+def _normalize_custom_base_model_path(model_name: str, *, base_url_enabled: bool) -> str:
+    normalized = model_name.strip()
+    parts = [part for part in normalized.split("/") if part]
+    if len(parts) >= 3 and parts[1] in _CANONICAL_CUSTOM_BASE_PROVIDERS:
+        provider = parts[1]
+        canonical = f"{provider}/{'/'.join(parts[2:])}"
+        if base_url_enabled:
+            return canonical
+        raise ValueError(f"Unsupported model path '{model_name}'. {_custom_base_url_usage_hint(provider)}")
+    return normalized
+
+
+def _normalize_request_model_routes(req: BaseModel | None) -> None:
+    if req is None:
+        return
+    providers = getattr(req, "providers", None) or {}
+    settings = get_settings()
+    for scope, model_field in _MODEL_FIELD_BY_SCOPE.items():
+        if not hasattr(req, model_field):
+            continue
+        provider_override = providers.get(scope)
+        base_url = (provider_override.base_url or "").strip() if provider_override else ""
+        explicit_model = getattr(req, model_field, None)
+        if explicit_model is None and not base_url:
+            continue
+        model_name = explicit_model or getattr(settings, model_field)
+        if not model_name:
+            continue
+        normalized_model = _normalize_custom_base_model_path(model_name, base_url_enabled=bool(base_url))
+        if base_url and custom_api_base_settings_field(scope, normalized_model) is None:
+            raise ValueError(_unsupported_custom_base_url_message(scope))
+        if explicit_model is not None:
+            setattr(req, model_field, normalized_model)
+
+
 def _normalize_optimization_error(exc: Exception, req: OptimizeRequest) -> str:
     if isinstance(exc, ModelHTTPError):
         text = str(exc)
@@ -799,11 +874,11 @@ def _normalize_optimization_error(exc: Exception, req: OptimizeRequest) -> str:
             custom_bases = _selected_custom_provider_bases(req)
             if custom_bases:
                 return (
-                    f"Custom OpenAI-compatible provider request failed before the model returned a usable response. "
+                    f"Custom provider request failed before the model returned a usable response. "
                     f"Check the base URL configuration ({'; '.join(custom_bases)}), API key, and that the endpoint supports models: {models}."
                 )
             return (
-                f"OpenAI-compatible provider request failed before the model returned a usable response. "
+                f"Provider request failed before the model returned a usable response. "
                 f"Check the API key, provider configuration, and model compatibility for: {models}."
             )
     return str(exc)
@@ -844,19 +919,22 @@ def _resolve_synthesis_documents(
 
 def _build_overrides(req: BaseModel | None) -> dict:
     """Build settings override dict from request fields."""
+    _normalize_request_model_routes(req)
     data = req.model_dump(exclude_none=True) if req is not None else {}
     overrides: dict = {}
     for field in ("pro_model", "flash_model", "embedding_model", "reasoning_effort", "api_keys"):
         if field in data:
             overrides[field] = data[field]
-    for scope, field_name in (
-        ("pro", "pro_openai_api_base"),
-        ("flash", "flash_openai_api_base"),
-        ("embedding", "embedding_openai_api_base"),
-    ):
+    for scope, model_field in _MODEL_FIELD_BY_SCOPE.items():
         provider_override = (data.get("providers") or {}).get(scope) or {}
-        if provider_override.get("base_url"):
-            overrides[field_name] = provider_override["base_url"]
+        base_url = (provider_override.get("base_url") or "").strip()
+        if not base_url:
+            continue
+        model_name = data.get(model_field) or getattr(get_settings(), model_field)
+        field_name = custom_api_base_settings_field(scope, model_name)
+        if field_name is None:
+            raise ValueError(_unsupported_custom_base_url_message(scope))
+        overrides[field_name] = base_url
     filter_thresholds = data.get("filter_thresholds")
     if filter_thresholds:
         threshold_map = {
@@ -908,9 +986,8 @@ def _request_from_form(
 
 
 
-async def _run_optimization(req: OptimizeRequest, source: ResumeSource):
+async def _run_optimization(req: OptimizeRequest, source: ResumeSource, overrides: dict):
     global _active_optimization
-    overrides = _build_overrides(req)
     with settings_override(overrides):
         await _run_optimization_inner(req, source)
 

--- a/src/hr_breaker/services/profile_store.py
+++ b/src/hr_breaker/services/profile_store.py
@@ -191,6 +191,34 @@ class ProfileStore:
             metadata=metadata,
         )
 
+    def update_note(self, profile_id: str, document_id: str, *, title: str, content_text: str) -> ProfileDocument | None:
+        doc = self.get_document(profile_id, document_id)
+        if doc is None or doc.kind != "note":
+            return None
+
+        metadata = {
+            key: value
+            for key, value in doc.metadata.items()
+            if key not in {"extraction", "extraction_status"}
+        }
+        updated = doc.model_copy(
+            update={
+                "title": title.strip(),
+                "source_name": title.strip(),
+                "content_text": content_text,
+                "metadata": metadata,
+                "timestamp": datetime.now(),
+            }
+        )
+        self._write_json_atomically(
+            self._document_path(profile_id, document_id),
+            updated.model_dump_json(indent=2),
+        )
+        profile = self.get_profile(profile_id)
+        if profile is not None:
+            self.save_profile(profile)
+        return updated
+
     def add_document(
         self,
         profile_id: str,

--- a/src/hr_breaker/static/css/style.css
+++ b/src/hr_breaker/static/css/style.css
@@ -549,8 +549,8 @@ label {
     text-transform: lowercase;
 }
 .extraction-done, .extraction-extracted { background: rgba(63, 185, 80, 0.15); color: var(--success); }
-.extraction-pending, .extraction-running { background: rgba(210, 153, 34, 0.15); color: var(--warning); }
-.extraction-error { background: rgba(248, 81, 73, 0.15); color: var(--error); }
+.extraction-pending, .extraction-running, .extraction-extracting { background: rgba(210, 153, 34, 0.15); color: var(--warning); }
+.extraction-error, .extraction-empty { background: rgba(248, 81, 73, 0.15); color: var(--error); }
 
 /* --- Doc count badge --- */
 .doc-count-badge {

--- a/src/hr_breaker/static/index.html
+++ b/src/hr_breaker/static/index.html
@@ -151,9 +151,30 @@
                                                             <span style="display: flex; align-items: center; gap: 6px">
                                                                 <span class="extraction-badge" :class="'extraction-' + (doc.extraction_status || 'pending')"
                                                                       x-text="doc.extraction_status || 'pending'"></span>
+                                                                <button class="btn-icon" x-show="doc.kind === 'note'"
+                                                                        @click.stop="startEditProfileNote(doc)" title="Edit note">✎</button>
                                                                 <button class="btn-remove" @click.stop="deleteProfileDoc(doc.id)" title="Remove">&times;</button>
                                                             </span>
                                                         </div>
+                                                        <template x-if="profile.editingNoteId === doc.id">
+                                                            <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border);">
+                                                                <input type="text" x-model="profile.editNoteTitle" placeholder="Note title"
+                                                                       style="margin-bottom: 6px" @keydown.enter.prevent="$el.nextElementSibling.focus()">
+                                                                <textarea x-model="profile.editNoteContent" placeholder="Note content..." rows="4"
+                                                                          style="margin-bottom: 6px; font-size: 0.85rem"></textarea>
+                                                                <div style="display: flex; gap: 6px;">
+                                                                    <button class="btn btn-secondary btn-sm"
+                                                                            @click="saveProfileNote"
+                                                                            :disabled="!profile.editNoteTitle.trim() || profile.savingNote">
+                                                                        <template x-if="profile.savingNote"><span class="spinner"></span></template>
+                                                                        Save
+                                                                    </button>
+                                                                    <button class="btn btn-ghost btn-sm" @click="cancelEditProfileNote">
+                                                                        Cancel
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </template>
                                                     </div>
                                                 </template>
                                             </div>
@@ -202,7 +223,13 @@
                                                         @click="reExtractProfile"
                                                         :disabled="profile.documents.length === 0"
                                                         title="Re-run extraction on all documents">
-                                                    ↻ Re-extract
+                                                    ↻ Extract all
+                                                </button>
+                                                <button class="btn btn-ghost btn-sm" style="flex: 0 0 auto"
+                                                        @click="reExtractFailed"
+                                                        :disabled="failedExtractionDocIds().length === 0"
+                                                        title="Re-run extraction on pending/error documents">
+                                                    ↻ Extract failed
                                                 </button>
                                                 <button class="btn btn-secondary btn-sm" style="flex: 1"
                                                         @click="closeProfileEditor()">

--- a/src/hr_breaker/static/index.html
+++ b/src/hr_breaker/static/index.html
@@ -551,7 +551,7 @@
                     <span class="chevron" :class="drawerSections.models && 'open'"></span>
                 </div>
                 <div class="sidebar-section-body" x-show="drawerSections.models">
-                    <div class="sidebar-hint" style="margin-bottom:6px">Provider is detected from the model path prefix (e.g. <code>gemini/</code>, <code>openrouter/</code>). Set API keys below.</div>
+                    <div class="sidebar-hint" style="margin-bottom:6px">Provider is detected from the model path prefix (e.g. <code>gemini/</code>, <code>openrouter/</code>). Set API keys below. Enable a custom base URL only when routing through a compatible proxy.</div>
 
                     <!-- Pro model (combobox) -->
                     <div class="setting-field" x-data="{ open: false, q: '' }">
@@ -559,30 +559,34 @@
                         <div class="combobox">
                             <input type="text"
                                    :value="open ? q : settings.proModel"
-                                   @focus="q = settings.proModel; open = true; onModelInput(q)"
-                                   @input="q = $event.target.value; open = true; onModelInput(q)"
-                                   @keydown.enter.prevent="settings.proModel = q; open = false; $event.target.blur()"
+                                   @focus="q = settings.proModel; open = true; onModelInput('pro', q)"
+                                   @input="q = $event.target.value; open = true; onModelInput('pro', q)"
+                                   @keydown.enter.prevent="settings.proModel = _normalizeModelPath(q); open = false; $event.target.blur()"
                                    @keydown.escape="open = false; $event.target.blur()"
-                                   @blur="setTimeout(() => { if (q) settings.proModel = q; open = false }, 150)"
+                                   @blur="setTimeout(() => { if (q) settings.proModel = _normalizeModelPath(q); open = false }, 150)"
                                    placeholder="e.g. gemini/gemini-3-pro-preview">
-                            <div class="combobox-list" x-show="open && chatModelsForText(q).length > 0">
-                                <template x-for="m in chatModelsForText(q).filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                            <div class="combobox-list" x-show="open && chatModelsForText(q, 'pro').length > 0">
+                                <template x-for="m in chatModelsForText(q, 'pro').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
                                     <div class="combobox-option"
                                          @mousedown.prevent="settings.proModel = m.value; q = m.value; open = false"
                                          x-text="m.value"></div>
                                 </template>
                                 <div class="combobox-empty"
-                                     x-show="q && chatModelsForText(q).filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                     x-show="q && chatModelsForText(q, 'pro').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
                                     No matches — press Enter to use custom value
                                 </div>
                             </div>
                         </div>
-                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.proModel)"
-                             :class="catalogMessageForText(settings.proModel)?.type"
-                             x-text="catalogMessageForText(settings.proModel)?.text" style="margin-top:3px"></div>
+                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.proModel, 'pro')"
+                             :class="catalogMessageForText(settings.proModel, 'pro')?.type"
+                             x-text="catalogMessageForText(settings.proModel, 'pro')?.text" style="margin-top:3px"></div>
+                        <div class="setting-row" x-show="_supportsCustomBaseUrl('pro')" style="margin-top:6px">
+                            <input type="checkbox" id="pro-custom-base" x-model="customBaseUrlEnabled.pro" @change="_saveToStorage(); fetchCatalog('pro')">
+                            <label for="pro-custom-base">Use custom base URL</label>
+                        </div>
                         <input type="text" x-model="customBaseUrls.pro"
-                               x-show="customBaseUrls.pro || !_extractProviderFromModel(settings.proModel)"
-                               @input="_saveToStorage()"
+                               x-show="customBaseUrlEnabled.pro && _supportsCustomBaseUrl('pro')"
+                               @change="_saveToStorage(); fetchCatalog('pro')"
                                placeholder="Base URL (for custom endpoints)" style="margin-top:4px;font-size:0.82rem">
                     </div>
 
@@ -592,30 +596,34 @@
                         <div class="combobox">
                             <input type="text"
                                    :value="open ? q : settings.flashModel"
-                                   @focus="q = settings.flashModel; open = true; onModelInput(q)"
-                                   @input="q = $event.target.value; open = true; onModelInput(q)"
-                                   @keydown.enter.prevent="settings.flashModel = q; open = false; $event.target.blur()"
+                                   @focus="q = settings.flashModel; open = true; onModelInput('flash', q)"
+                                   @input="q = $event.target.value; open = true; onModelInput('flash', q)"
+                                   @keydown.enter.prevent="settings.flashModel = _normalizeModelPath(q); open = false; $event.target.blur()"
                                    @keydown.escape="open = false; $event.target.blur()"
-                                   @blur="setTimeout(() => { if (q) settings.flashModel = q; open = false }, 150)"
+                                   @blur="setTimeout(() => { if (q) settings.flashModel = _normalizeModelPath(q); open = false }, 150)"
                                    placeholder="e.g. gemini/gemini-3-flash-preview">
-                            <div class="combobox-list" x-show="open && chatModelsForText(q).length > 0">
-                                <template x-for="m in chatModelsForText(q).filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                            <div class="combobox-list" x-show="open && chatModelsForText(q, 'flash').length > 0">
+                                <template x-for="m in chatModelsForText(q, 'flash').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
                                     <div class="combobox-option"
                                          @mousedown.prevent="settings.flashModel = m.value; q = m.value; open = false"
                                          x-text="m.value"></div>
                                 </template>
                                 <div class="combobox-empty"
-                                     x-show="q && chatModelsForText(q).filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                     x-show="q && chatModelsForText(q, 'flash').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
                                     No matches — press Enter to use custom value
                                 </div>
                             </div>
                         </div>
-                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.flashModel)"
-                             :class="catalogMessageForText(settings.flashModel)?.type"
-                             x-text="catalogMessageForText(settings.flashModel)?.text" style="margin-top:3px"></div>
+                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.flashModel, 'flash')"
+                             :class="catalogMessageForText(settings.flashModel, 'flash')?.type"
+                             x-text="catalogMessageForText(settings.flashModel, 'flash')?.text" style="margin-top:3px"></div>
+                        <div class="setting-row" x-show="_supportsCustomBaseUrl('flash')" style="margin-top:6px">
+                            <input type="checkbox" id="flash-custom-base" x-model="customBaseUrlEnabled.flash" @change="_saveToStorage(); fetchCatalog('flash')">
+                            <label for="flash-custom-base">Use custom base URL</label>
+                        </div>
                         <input type="text" x-model="customBaseUrls.flash"
-                               x-show="customBaseUrls.flash || !_extractProviderFromModel(settings.flashModel)"
-                               @input="_saveToStorage()"
+                               x-show="customBaseUrlEnabled.flash && _supportsCustomBaseUrl('flash')"
+                               @change="_saveToStorage(); fetchCatalog('flash')"
                                placeholder="Base URL (for custom endpoints)" style="margin-top:4px;font-size:0.82rem">
                     </div>
 
@@ -625,30 +633,34 @@
                         <div class="combobox">
                             <input type="text"
                                    :value="open ? q : settings.embeddingModel"
-                                   @focus="q = settings.embeddingModel; open = true; onModelInput(q)"
-                                   @input="q = $event.target.value; open = true; onModelInput(q)"
-                                   @keydown.enter.prevent="settings.embeddingModel = q; open = false; $event.target.blur()"
+                                   @focus="q = settings.embeddingModel; open = true; onModelInput('embedding', q)"
+                                   @input="q = $event.target.value; open = true; onModelInput('embedding', q)"
+                                   @keydown.enter.prevent="settings.embeddingModel = _normalizeModelPath(q); open = false; $event.target.blur()"
                                    @keydown.escape="open = false; $event.target.blur()"
-                                   @blur="setTimeout(() => { if (q) settings.embeddingModel = q; open = false }, 150)"
+                                   @blur="setTimeout(() => { if (q) settings.embeddingModel = _normalizeModelPath(q); open = false }, 150)"
                                    placeholder="e.g. openrouter/google/gemini-embedding-001">
-                            <div class="combobox-list" x-show="open && embeddingModelsForText(q).length > 0">
-                                <template x-for="m in embeddingModelsForText(q).filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
+                            <div class="combobox-list" x-show="open && embeddingModelsForText(q, 'embedding').length > 0">
+                                <template x-for="m in embeddingModelsForText(q, 'embedding').filter(m => !q || m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase()))" :key="m.value">
                                     <div class="combobox-option"
                                          @mousedown.prevent="settings.embeddingModel = m.value; q = m.value; open = false"
                                          x-text="m.value"></div>
                                 </template>
                                 <div class="combobox-empty"
-                                     x-show="q && embeddingModelsForText(q).filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
+                                     x-show="q && embeddingModelsForText(q, 'embedding').filter(m => m.label.toLowerCase().includes(q.toLowerCase()) || m.value.toLowerCase().includes(q.toLowerCase())).length === 0">
                                     No matches — press Enter to use custom value
                                 </div>
                             </div>
                         </div>
-                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.embeddingModel)"
-                             :class="catalogMessageForText(settings.embeddingModel)?.type"
-                             x-text="catalogMessageForText(settings.embeddingModel)?.text" style="margin-top:3px"></div>
+                        <div class="sidebar-hint catalog-status" x-show="catalogMessageForText(settings.embeddingModel, 'embedding')"
+                             :class="catalogMessageForText(settings.embeddingModel, 'embedding')?.type"
+                             x-text="catalogMessageForText(settings.embeddingModel, 'embedding')?.text" style="margin-top:3px"></div>
+                        <div class="setting-row" x-show="_supportsCustomBaseUrl('embedding')" style="margin-top:6px">
+                            <input type="checkbox" id="embedding-custom-base" x-model="customBaseUrlEnabled.embedding" @change="_saveToStorage(); fetchCatalog('embedding')">
+                            <label for="embedding-custom-base">Use custom base URL</label>
+                        </div>
                         <input type="text" x-model="customBaseUrls.embedding"
-                               x-show="customBaseUrls.embedding || !_extractProviderFromModel(settings.embeddingModel)"
-                               @input="_saveToStorage()"
+                               x-show="customBaseUrlEnabled.embedding && _supportsCustomBaseUrl('embedding')"
+                               @change="_saveToStorage(); fetchCatalog('embedding')"
                                placeholder="Base URL (for custom endpoints)" style="margin-top:4px;font-size:0.82rem">
                     </div>
 
@@ -679,13 +691,13 @@
                             <label x-text="label"></label>
                             <div class="key-input-row">
                                 <input type="password" x-model="settings.apiKeys[key]"
-                                       @input="fetchCatalog(key)"
+                                       @input="fetchCatalogsForProvider(key)"
                                        :placeholder="appSettings.apiKeysSet[key] ? '(set in .env)' : '(not set)'">
                                 <span class="key-status"
                                       :class="(settings.apiKeys[key] || appSettings.apiKeysSet[key]) ? 'key-set' : 'key-unset'"
                                       x-text="(settings.apiKeys[key] || appSettings.apiKeysSet[key]) ? '✓' : ''"></span>
                                 <button class="btn btn-ghost btn-sm" style="padding:2px 5px;font-size:0.8rem;flex-shrink:0"
-                                        @click="fetchCatalog(key)" title="Refresh models">↻</button>
+                                        @click="fetchCatalogsForProvider(key)" title="Refresh models">↻</button>
                             </div>
                         </div>
                     </template>

--- a/src/hr_breaker/static/js/app.js
+++ b/src/hr_breaker/static/js/app.js
@@ -101,8 +101,9 @@ document.addEventListener('alpine:init', () => {
 
         // Model catalog cache (keyed by provider prefix)
         modelCatalog: {},
-        // Per-model base URLs for custom/OpenAI-compatible endpoints
+        // Per-model custom endpoint state
         customBaseUrls: { pro: '', flash: '', embedding: '' },
+        customBaseUrlEnabled: { pro: false, flash: false, embedding: false },
 
         // Cached resumes/jobs for pickers
         cachedResumes: [],
@@ -188,6 +189,7 @@ document.addEventListener('alpine:init', () => {
 
             // Load model catalogs for detected providers
             await this.fetchAllCatalogs();
+            this._saveToStorage();
         },
 
         _storageKey: 'hr-breaker-state',
@@ -198,6 +200,7 @@ document.addEventListener('alpine:init', () => {
                 settings: this.settings,
                 drawerSections: this.drawerSections,
                 customBaseUrls: this.customBaseUrls,
+                customBaseUrlEnabled: this.customBaseUrlEnabled,
                 selectedResumeChecksum: this.resume.checksum,
             };
             try { localStorage.setItem(this._storageKey, JSON.stringify(state)); } catch {}
@@ -220,6 +223,15 @@ document.addEventListener('alpine:init', () => {
                 if (state.customBaseUrls && typeof state.customBaseUrls === 'object') {
                     Object.assign(this.customBaseUrls, state.customBaseUrls);
                 }
+                if (state.customBaseUrlEnabled && typeof state.customBaseUrlEnabled === 'object') {
+                    Object.assign(this.customBaseUrlEnabled, state.customBaseUrlEnabled);
+                }
+                for (const scope of ['pro', 'flash', 'embedding']) {
+                    if ((!state.customBaseUrlEnabled || !(scope in state.customBaseUrlEnabled)) && this.customBaseUrls[scope]) {
+                        this.customBaseUrlEnabled[scope] = true;
+                    }
+                }
+                this._sanitizeStoredModelPaths();
                 if (state.selectedResumeChecksum) {
                     this._savedResumeChecksum = state.selectedResumeChecksum;
                 }
@@ -268,6 +280,7 @@ document.addEventListener('alpine:init', () => {
                 if (!this.settings.flashModel) this.settings.flashModel = data.flash_model || '';
                 if (!this.settings.embeddingModel) this.settings.embeddingModel = data.embedding_model || '';
                 if (!this.settings.reasoningEffort) this.settings.reasoningEffort = data.reasoning_effort || '';
+                this._sanitizeStoredModelPaths();
                 if (!this._restoredFromStorage) {
                     this.settings.language = data.default_language;
                     this.settings.maxIterations = data.max_iterations;
@@ -903,15 +916,46 @@ document.addEventListener('alpine:init', () => {
 
         // --- Provider / catalog actions ---
 
-        _extractProviderFromModel(modelPath) {
-            if (!modelPath) return null;
+        _modelRouteInfo(modelPath) {
+            const normalized = (modelPath || '').trim();
+            if (!normalized) return { provider: null, canonicalModel: '' };
+            const parts = normalized.split('/').filter(Boolean);
+            if (parts.length >= 3 && ['openai', 'anthropic'].includes(parts[1])) {
+                return {
+                    provider: parts[1],
+                    canonicalModel: `${parts[1]}/${parts.slice(2).join('/')}`
+                };
+            }
             const known = ['gemini', 'openrouter', 'openai', 'anthropic', 'moonshot'];
-            const prefix = modelPath.split('/')[0];
-            return known.includes(prefix) ? prefix : null;
+            const provider = known.includes(parts[0]) ? parts[0] : null;
+            return { provider, canonicalModel: normalized };
+        },
+
+        _normalizeModelPath(modelPath) {
+            return this._modelRouteInfo(modelPath).canonicalModel;
+        },
+
+        _sanitizeStoredModelPaths() {
+            for (const key of ['proModel', 'flashModel', 'embeddingModel']) {
+                const normalized = this._normalizeModelPath(this.settings[key]);
+                if (normalized !== this.settings[key]) {
+                    this.settings[key] = normalized;
+                }
+            }
+        },
+
+        _extractProviderFromModel(modelPath) {
+            return this._modelRouteInfo(modelPath).provider;
         },
 
         _modelKeyForScope(scope) {
             return { pro: 'proModel', flash: 'flashModel', embedding: 'embeddingModel' }[scope];
+        },
+
+        _supportsCustomBaseUrl(scope, modelPath = null) {
+            const provider = this._extractProviderFromModel(modelPath ?? this.settings[this._modelKeyForScope(scope)]);
+            if (scope === 'embedding') return provider === 'openai';
+            return provider === 'openai' || provider === 'anthropic';
         },
 
         _providerForScope(scope) {
@@ -928,25 +972,39 @@ document.addEventListener('alpine:init', () => {
             return this.appSettings.apiKeysSet[provider] || false;
         },
 
-        _catalogEntry(provider) {
-            if (!provider) return null;
-            return this.modelCatalog[provider] || null;
+        _customBaseUrlForScope(scope, modelPath = null) {
+            if (!this.customBaseUrlEnabled[scope]) return null;
+            const candidateModelPath = modelPath ?? this.settings[this._modelKeyForScope(scope)];
+            if (!this._supportsCustomBaseUrl(scope, candidateModelPath)) return null;
+            const url = (this.customBaseUrls[scope] || '').trim();
+            return url || null;
         },
 
-        chatModelsForText(text) {
+        _catalogCacheKey(provider, baseUrl = null) {
+            if (!provider) return null;
+            return `${provider}::${(baseUrl || '').trim()}`;
+        },
+
+        _catalogEntry(provider, baseUrl = null) {
+            const key = this._catalogCacheKey(provider, baseUrl);
+            if (!key) return null;
+            return this.modelCatalog[key] || null;
+        },
+
+        chatModelsForText(text, scope = null) {
             const provider = this._extractProviderFromModel(text);
-            const entry = this._catalogEntry(provider);
+            const entry = this._catalogEntry(provider, scope ? this._customBaseUrlForScope(scope, text) : null);
             return entry ? (entry.chatModels || []) : [];
         },
 
-        embeddingModelsForText(text) {
+        embeddingModelsForText(text, scope = null) {
             const provider = this._extractProviderFromModel(text);
-            const entry = this._catalogEntry(provider);
+            const entry = this._catalogEntry(provider, scope ? this._customBaseUrlForScope(scope, text) : null);
             return entry ? (entry.embeddingModels || []) : [];
         },
 
         catalogStatusForScope(scope) {
-            const entry = this._catalogEntry(this._providerForScope(scope));
+            const entry = this._catalogEntry(this._providerForScope(scope), this._customBaseUrlForScope(scope));
             return entry || { status: 'unknown', message: '', detail: '', checking: false };
         },
 
@@ -954,7 +1012,7 @@ document.addEventListener('alpine:init', () => {
             const result = {};
             let hasAny = false;
             for (const scope of ['pro', 'flash', 'embedding']) {
-                const url = (this.customBaseUrls[scope] || '').trim();
+                const url = this._customBaseUrlForScope(scope);
                 if (url) {
                     result[scope] = { base_url: url };
                     hasAny = true;
@@ -963,10 +1021,10 @@ document.addEventListener('alpine:init', () => {
             return hasAny ? result : null;
         },
 
-        catalogMessageForText(text) {
+        catalogMessageForText(text, scope = null) {
             const provider = this._extractProviderFromModel(text);
             if (!provider) return null;
-            const entry = this._catalogEntry(provider);
+            const entry = this._catalogEntry(provider, scope ? this._customBaseUrlForScope(scope, text) : null);
             if (!entry) return null;
             if (entry.checking) return { type: 'info', text: 'Loading models...' };
             if (entry.status === 'connected') return null;
@@ -974,22 +1032,27 @@ document.addEventListener('alpine:init', () => {
             return null;
         },
 
-        async fetchCatalog(provider) {
+        async fetchCatalog(scope, options = {}) {
+            const modelPath = options.modelPath ?? this.settings[this._modelKeyForScope(scope)];
+            const provider = this._extractProviderFromModel(modelPath);
             if (!provider) return;
-            const existing = this.modelCatalog[provider];
+            const baseUrl = this._customBaseUrlForScope(scope, modelPath);
+            const cacheKey = this._catalogCacheKey(provider, baseUrl);
+            if (!cacheKey) return;
+            const existing = this.modelCatalog[cacheKey];
             if (existing && existing.checking) return;
 
             const apiKey = this._apiKeyForProvider(provider) || null;
             const hasEnvKey = this._hasEnvKeyForProvider(provider);
             if (!apiKey && !hasEnvKey) {
-                this.modelCatalog[provider] = { status: 'warning', message: `Set ${provider} API key in API Keys section to browse models`, detail: '', chatModels: [], embeddingModels: [], checking: false };
+                this.modelCatalog[cacheKey] = { status: 'warning', message: `Set ${provider} API key in API Keys section to browse models`, detail: '', chatModels: [], embeddingModels: [], checking: false };
                 return;
             }
 
-            this.modelCatalog[provider] = { ...(existing || {}), status: 'unknown', message: 'Loading...', detail: '', checking: true, chatModels: existing?.chatModels || [], embeddingModels: existing?.embeddingModels || [] };
+            this.modelCatalog[cacheKey] = { ...(existing || {}), status: 'unknown', message: 'Loading...', detail: '', checking: true, chatModels: existing?.chatModels || [], embeddingModels: existing?.embeddingModels || [] };
 
             try {
-                const body = { provider, api_key: apiKey };
+                const body = { provider, api_key: apiKey, base_url: baseUrl };
                 const resp = await fetch('/api/providers/check', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -997,7 +1060,7 @@ document.addEventListener('alpine:init', () => {
                 });
                 const data = await resp.json();
                 if (!resp.ok) throw new Error(data.detail || data.error || data.message || 'Request failed');
-                this.modelCatalog[provider] = {
+                this.modelCatalog[cacheKey] = {
                     status: data.status.state,
                     message: data.status.message,
                     detail: data.status.detail || '',
@@ -1006,7 +1069,7 @@ document.addEventListener('alpine:init', () => {
                     checking: false,
                 };
             } catch (e) {
-                this.modelCatalog[provider] = {
+                this.modelCatalog[cacheKey] = {
                     status: 'warning',
                     message: 'Check failed',
                     detail: e instanceof Error ? e.message : String(e),
@@ -1018,18 +1081,21 @@ document.addEventListener('alpine:init', () => {
         },
 
         async fetchAllCatalogs() {
-            const providers = new Set(
-                ['pro', 'flash', 'embedding'].map(s => this._providerForScope(s)).filter(Boolean)
-            );
-            await Promise.all([...providers].map(p => this.fetchCatalog(p)));
+            const scopes = ['pro', 'flash', 'embedding'].filter(scope => this._providerForScope(scope));
+            await Promise.all(scopes.map(scope => this.fetchCatalog(scope)));
         },
 
-        onModelInput(text) {
+        async fetchCatalogsForProvider(provider) {
+            const scopes = ['pro', 'flash', 'embedding'].filter(scope => this._providerForScope(scope) === provider);
+            await Promise.all(scopes.map(scope => this.fetchCatalog(scope)));
+        },
+
+        onModelInput(scope, text) {
             const provider = this._extractProviderFromModel(text);
             if (!provider) return;
-            const entry = this._catalogEntry(provider);
+            const entry = this._catalogEntry(provider, this._customBaseUrlForScope(scope, text));
             if (!entry || (!entry.chatModels?.length && !entry.embeddingModels?.length && entry.status !== 'connected')) {
-                this.fetchCatalog(provider);
+                this.fetchCatalog(scope, { modelPath: text });
             }
         },
 

--- a/src/hr_breaker/static/js/app.js
+++ b/src/hr_breaker/static/js/app.js
@@ -96,6 +96,10 @@ document.addEventListener('alpine:init', () => {
             noteTitle: '',
             noteContent: '',
             addingNote: false,
+            editingNoteId: null,
+            editNoteTitle: '',
+            editNoteContent: '',
+            savingNote: false,
             _pollTimer: null,
         },
 
@@ -1172,6 +1176,7 @@ document.addEventListener('alpine:init', () => {
             this.profile.showDocCustomize = false;
             this.profile.extractionLogs = [];
             this.profile.error = null;
+            this.cancelEditProfileNote();
             await this._refreshProfileDocs(p.id);
             this._startExtractionPoll(p.id);
         },
@@ -1185,6 +1190,7 @@ document.addEventListener('alpine:init', () => {
             this.profile.showDocCustomize = false;
             this.profile.extractionLogs = [];
             this.profile.showNoteForm = false;
+            this.cancelEditProfileNote();
             this.profile.error = null;
         },
 
@@ -1227,6 +1233,8 @@ document.addEventListener('alpine:init', () => {
                 if (!resp.ok) return;
                 const data = await resp.json();
                 const documents = data.documents || [];
+                const extractingIds = new Set(data.extracting || []);
+                documents.forEach(d => { if (extractingIds.has(d.id)) d.extraction_status = "extracting"; });
                 this.profile.documents = documents;
                 if (this.profile.selectionCustomized) {
                     const currentIds = new Set(documents.map((doc) => doc.id));
@@ -1344,6 +1352,33 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
+
+        failedExtractionDocIds() {
+            return (this.profile.documents || []).filter(
+                d => !d.extraction_status || d.extraction_status === "pending" || d.extraction_status === "error" || d.extraction_status === "empty"
+            ).map(d => d.id);
+        },
+
+        async reExtractFailed() {
+            const docIds = this.failedExtractionDocIds();
+            if (!this.profile.editingId || docIds.length === 0) return;
+            this.profile.error = null;
+            try {
+                const pid = this.profile.editingId;
+                const body = { ...this._profileRunOverrides(), doc_ids: docIds };
+                const resp = await fetch("/api/profile/" + pid + "/extract", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(body),
+                });
+                const data = await resp.json();
+                if (!resp.ok) { this.profile.error = data.error || "Extract failed"; return; }
+                await this._refreshProfileDocs(pid);
+                this._startExtractionPoll(pid);
+            } catch (e) {
+                this.profile.error = "Extract failed: " + e.message;
+            }
+        },
         async addProfileNote() {
             if (!this.profile.editingId || !this.profile.noteTitle.trim()) return;
             this.profile.addingNote = true;
@@ -1368,6 +1403,49 @@ document.addEventListener('alpine:init', () => {
             } catch (e) {
                 this.profile.error = 'Failed to add note: ' + e.message;
                 this.profile.addingNote = false;
+            }
+        },
+
+        startEditProfileNote(doc) {
+            if (!doc || doc.kind !== 'note') return;
+            this.profile.showNoteForm = false;
+            this.profile.editingNoteId = doc.id;
+            this.profile.editNoteTitle = doc.title || '';
+            this.profile.editNoteContent = doc.content || '';
+            this.profile.error = null;
+        },
+
+        cancelEditProfileNote() {
+            this.profile.editingNoteId = null;
+            this.profile.editNoteTitle = '';
+            this.profile.editNoteContent = '';
+            this.profile.savingNote = false;
+        },
+
+        async saveProfileNote() {
+            if (!this.profile.editingId || !this.profile.editingNoteId || !this.profile.editNoteTitle.trim()) return;
+            this.profile.savingNote = true;
+            this.profile.error = null;
+            try {
+                const resp = await fetch('/api/profile/' + this.profile.editingId + '/note/' + this.profile.editingNoteId, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        title: this.profile.editNoteTitle.trim(),
+                        content: this.profile.editNoteContent.trim(),
+                    }),
+                });
+                if (!resp.ok) {
+                    const text = await resp.text();
+                    try { const j = JSON.parse(text); throw new Error(j.detail || j.error || text); }
+                    catch (pe) { if (pe instanceof SyntaxError) throw new Error(text); throw pe; }
+                }
+                this.cancelEditProfileNote();
+                await this._refreshProfileDocs(this.profile.editingId);
+                this._startExtractionPoll(this.profile.editingId);
+            } catch (e) {
+                this.profile.error = 'Failed to save note: ' + e.message;
+                this.profile.savingNote = false;
             }
         },
 

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -72,6 +72,37 @@ class TestSettingsOverride:
             assert getattr(config_module.get_flash_model(), "_api_base") == "https://openai.flash.example.test/v1"
             assert config_module.get_embedding_api_base() == "https://openai.embed.example.test/v1"
 
+    def test_shared_openai_compatible_base_routes_openai_models(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("PRO_OPENAI_API_BASE", raising=False)
+        monkeypatch.delenv("FLASH_OPENAI_API_BASE", raising=False)
+        monkeypatch.setenv("LLM_SHARED_PROVIDER", "openai_compatible")
+        monkeypatch.setenv("LLM_SHARED_BASE_URL", "https://proxy.example.test/v1")
+        monkeypatch.setenv("FLASH_MODEL", "openai/gpt-5.4-mini")
+        config_module.get_settings.cache_clear()
+
+        assert getattr(config_module.get_flash_model(), "_api_base") == "https://proxy.example.test/v1"
+
+    def test_shared_openai_compatible_base_replaces_empty_openai_base(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_BASE", "")
+        monkeypatch.setenv("LLM_SHARED_PROVIDER", "openai_compatible")
+        monkeypatch.setenv("LLM_SHARED_BASE_URL", "https://proxy.example.test/v1")
+        monkeypatch.setenv("FLASH_MODEL", "openai/gpt-5.4-mini")
+        config_module.get_settings.cache_clear()
+
+        assert getattr(config_module.get_flash_model(), "_api_base") == "https://proxy.example.test/v1"
+
+    def test_shared_openai_compatible_api_key_populates_openai_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("LLM_SHARED_PROVIDER", "openai_compatible")
+        monkeypatch.setenv("LLM_SHARED_API_KEY", "sk-shared-test")
+        config_module.get_settings.cache_clear()
+
+        config_module.get_settings()
+
+        assert os.environ.get("OPENAI_API_KEY") == "sk-shared-test"
+
     def test_custom_api_base_settings_field_is_scope_aware(self):
         assert config_module.custom_api_base_settings_field("pro", "openai/gpt-5.4") == "pro_openai_api_base"
         assert config_module.custom_api_base_settings_field("flash", "anthropic/claude-sonnet-4-5") == "flash_anthropic_api_base"

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -2,7 +2,6 @@ import os
 import threading
 import time
 
-import pytest
 
 import hr_breaker.config as config_module
 
@@ -43,6 +42,41 @@ class TestSettingsOverride:
             assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == "https://embed.example.test/v1"
         assert os.environ.get("FLASH_OPENAI_API_BASE") == original_flash
         assert os.environ.get("EMBEDDING_OPENAI_API_BASE") == original_embedding
+
+
+    def test_override_scoped_anthropic_api_bases(self):
+        original_pro = os.environ.get("PRO_ANTHROPIC_API_BASE")
+        original_flash = os.environ.get("FLASH_ANTHROPIC_API_BASE")
+        with config_module.settings_override({
+            "pro_anthropic_api_base": "https://pro.anthropic.example.test",
+            "flash_anthropic_api_base": "https://flash.anthropic.example.test",
+        }):
+            assert os.environ.get("PRO_ANTHROPIC_API_BASE") == "https://pro.anthropic.example.test"
+            assert os.environ.get("FLASH_ANTHROPIC_API_BASE") == "https://flash.anthropic.example.test"
+        assert os.environ.get("PRO_ANTHROPIC_API_BASE") == original_pro
+        assert os.environ.get("FLASH_ANTHROPIC_API_BASE") == original_flash
+
+    def test_litellm_routing_uses_scope_specific_api_bases(self):
+        with config_module.settings_override({
+            "pro_model": "anthropic/claude-sonnet-4-5",
+            "flash_model": "openai/gpt-5.4-mini",
+            "embedding_model": "openai/text-embedding-3-small",
+            "anthropic_api_base": "https://anthropic.default.example.test",
+            "pro_anthropic_api_base": "https://anthropic.pro.example.test",
+            "flash_openai_api_base": "https://openai.flash.example.test/v1",
+            "embedding_openai_api_base": "https://openai.embed.example.test/v1",
+        }):
+            assert config_module.get_pro_model().model_name == "anthropic/claude-sonnet-4-5"
+            assert getattr(config_module.get_pro_model(), "_api_base") == "https://anthropic.pro.example.test"
+            assert config_module.get_flash_model().model_name == "openai/gpt-5.4-mini"
+            assert getattr(config_module.get_flash_model(), "_api_base") == "https://openai.flash.example.test/v1"
+            assert config_module.get_embedding_api_base() == "https://openai.embed.example.test/v1"
+
+    def test_custom_api_base_settings_field_is_scope_aware(self):
+        assert config_module.custom_api_base_settings_field("pro", "openai/gpt-5.4") == "pro_openai_api_base"
+        assert config_module.custom_api_base_settings_field("flash", "anthropic/claude-sonnet-4-5") == "flash_anthropic_api_base"
+        assert config_module.custom_api_base_settings_field("embedding", "openai/text-embedding-3-small") == "embedding_openai_api_base"
+        assert config_module.custom_api_base_settings_field("embedding", "anthropic/claude-sonnet-4-5") is None
 
 
     def test_empty_override_is_noop(self):

--- a/tests/test_frontend_model_catalog.py
+++ b/tests/test_frontend_model_catalog.py
@@ -1,0 +1,119 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+APP_JS_PATH = Path(__file__).resolve().parents[1] / "src/hr_breaker/static/js/app.js"
+
+
+def _run_app_probe(script_body: str):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for frontend catalog tests")
+
+    harness = f"""
+const fs = require('fs');
+const vm = require('vm');
+const source = fs.readFileSync({json.dumps(str(APP_JS_PATH))}, 'utf8');
+let factory = null;
+const document = {{ addEventListener(event, cb) {{ if (event === 'alpine:init') cb(); }} }};
+const Alpine = {{ data(name, fn) {{ if (name === 'app') factory = fn; }} }};
+const context = {{
+  console,
+  document,
+  Alpine,
+  URL,
+  setTimeout,
+  clearTimeout,
+  fetch: async () => {{ throw new Error('fetch not stubbed'); }},
+}};
+vm.createContext(context);
+vm.runInContext(source, context);
+if (!factory) throw new Error('Failed to capture Alpine app factory');
+const app = factory();
+(async () => {{
+{script_body}
+}})().catch(err => {{
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+}});
+"""
+    completed = subprocess.run([node, "-e", harness], check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def test_on_model_input_fetches_catalog_for_typed_provider_and_scope_base_url():
+    payload = _run_app_probe(
+        """
+  app.settings.flashModel = 'gemini/gemini-2.5-flash';
+  app.customBaseUrlEnabled.flash = true;
+  app.customBaseUrls.flash = 'http://127.0.0.1:8317/v1';
+  app.appSettings.apiKeysSet.openai = true;
+  app.appSettings.apiKeysSet.gemini = true;
+
+  const requests = [];
+  context.fetch = async (_url, options) => {
+    requests.push(JSON.parse(options.body));
+    return {
+      ok: true,
+      json: async () => ({
+        status: { state: 'connected', message: 'Connected' },
+        chat_models: [],
+        embedding_models: [],
+      }),
+    };
+  };
+
+  app.onModelInput('flash', 'openai/gpt-5.4-mini');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  process.stdout.write(JSON.stringify(requests[0]));
+"""
+    )
+
+    assert payload == {
+        "provider": "openai",
+        "api_key": None,
+        "base_url": "http://127.0.0.1:8317/v1",
+    }
+
+
+def test_catalog_message_uses_scope_specific_cache_key_for_same_provider():
+    payload = _run_app_probe(
+        """
+  app.settings.proModel = 'openai/gpt-5.4';
+  app.customBaseUrlEnabled.pro = true;
+  app.customBaseUrls.pro = 'https://pro.example.test/v1';
+  app.settings.flashModel = 'openai/gpt-5.4-mini';
+  app.customBaseUrlEnabled.flash = true;
+  app.customBaseUrls.flash = 'https://flash.example.test/v1';
+
+  app.modelCatalog[app._catalogCacheKey('openai', app._customBaseUrlForScope('pro'))] = {
+    status: 'warning',
+    message: 'pro endpoint failed',
+    detail: '',
+    checking: false,
+    chatModels: [],
+    embeddingModels: [],
+  };
+  app.modelCatalog[app._catalogCacheKey('openai', app._customBaseUrlForScope('flash'))] = {
+    status: 'warning',
+    message: 'flash endpoint failed',
+    detail: '',
+    checking: false,
+    chatModels: [],
+    embeddingModels: [],
+  };
+
+  const pro = app.catalogMessageForText('openai/gpt-5.4', 'pro');
+  const flash = app.catalogMessageForText('openai/gpt-5.4-mini', 'flash');
+  process.stdout.write(JSON.stringify({ pro: pro?.text || null, flash: flash?.text || null }));
+"""
+    )
+
+    assert payload == {
+        "pro": "pro endpoint failed",
+        "flash": "flash endpoint failed",
+    }

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -67,6 +67,34 @@ def test_profile_store_deduplicates_matching_uploads_and_updates_timestamp(tmp_p
     assert note.source_name == "Hackathon"
 
 
+def test_profile_store_updates_note_and_clears_stale_extraction(tmp_path):
+    store = ProfileStore(root_dir=tmp_path)
+    profile = store.create_profile("Jane Doe")
+    note = store.add_note(
+        profile.id,
+        title="Hackathon",
+        content_text="Won first place.",
+        metadata={"extraction": {"summary": ["old"]}, "extraction_status": "done", "keep": "yes"},
+    )
+
+    updated = store.update_note(
+        profile.id,
+        note.id,
+        title="Awards",
+        content_text="Won second place.",
+    )
+    reloaded = store.get_document(profile.id, note.id)
+
+    assert updated is not None
+    assert reloaded is not None
+    assert reloaded.title == "Awards"
+    assert reloaded.source_name == "Awards"
+    assert reloaded.content_text == "Won second place."
+    assert "extraction" not in reloaded.metadata
+    assert "extraction_status" not in reloaded.metadata
+    assert reloaded.metadata["keep"] == "yes"
+
+
 @pytest.mark.asyncio
 async def test_extract_document_content_does_not_recreate_deleted_document(tmp_path):
     store = ProfileStore(root_dir=tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,12 +505,90 @@ async def test_delete_profile_document_cancels_worker_before_removal(client, mon
         config_module.clear_settings_cache()
 
 
+@pytest.mark.asyncio
+async def test_get_profile_returns_note_content_only_for_notes(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        note = store.add_note(profile.id, title="Note", content_text="editable note")
+        upload = store.add_upload(profile.id, filename="resume.txt", data=b"resume text")
+
+        resp = await client.get(f"/api/profile/{profile.id}")
+
+        assert resp.status_code == 200
+        docs = {doc["id"]: doc for doc in resp.json()["documents"]}
+        assert docs[note.id]["content"] == "editable note"
+        assert docs[upload.id]["content"] is None
+    finally:
+        config_module.clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_update_profile_note_updates_content_and_reextracts(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        note = store.add_note(
+            profile.id,
+            title="Old",
+            content_text="old content",
+            metadata={"extraction": {"summary": ["old"]}, "extraction_status": "done"},
+        )
+
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.cancel") as mock_cancel, patch(
+            "hr_breaker.services.extraction_worker.extraction_worker.submit"
+        ) as mock_submit:
+            resp = await client.patch(
+                f"/api/profile/{profile.id}/note/{note.id}",
+                json={"title": "New", "content": "new content"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"id": note.id, "title": "New", "kind": "note", "content": "new content"}
+        updated = store.get_document(profile.id, note.id)
+        assert updated is not None
+        assert updated.title == "New"
+        assert updated.content_text == "new content"
+        assert "extraction" not in updated.metadata
+        assert "extraction_status" not in updated.metadata
+        mock_cancel.assert_called_once_with([note.id])
+        mock_submit.assert_called_once_with(profile.id, [note.id])
+    finally:
+        config_module.clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_update_profile_note_rejects_non_notes(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        doc = store.add_upload(profile.id, filename="resume.txt", data=b"resume text")
+
+        resp = await client.patch(
+            f"/api/profile/{profile.id}/note/{doc.id}",
+            json={"title": "Nope", "content": "changed"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Only notes can be edited"
+    finally:
+        config_module.clear_settings_cache()
+
+
 
 @pytest.mark.asyncio
 async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp_path):
     monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("LLM_SHARED_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_SHARED_BASE_URL", raising=False)
     config_module.clear_settings_cache()
     try:
         store = ProfileStore()
@@ -687,3 +765,34 @@ async def test_optimize_rejects_legacy_custom_prefix_without_base_url(client):
 
     assert resp.status_code == 400
     assert "Use `openai/<model>`" in resp.json()["error"]
+
+@pytest.mark.asyncio
+async def test_update_profile_note_noop_skips_reextraction(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("PROFILE_DIR", str(tmp_path))
+    config_module.clear_settings_cache()
+    try:
+        store = ProfileStore()
+        profile = store.create_profile("Candidate")
+        note = store.add_note(
+            profile.id,
+            title="Same",
+            content_text="same content",
+            metadata={"extraction": {"summary": ["kept"]}, "extraction_status": "done"},
+        )
+
+        with patch("hr_breaker.services.extraction_worker.extraction_worker.cancel") as mock_cancel, patch(
+            "hr_breaker.services.extraction_worker.extraction_worker.submit"
+        ) as mock_submit:
+            resp = await client.patch(
+                f"/api/profile/{profile.id}/note/{note.id}",
+                json={"title": "Same", "content": "same content"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"id": note.id, "title": "Same", "kind": "note", "content": "same content"}
+        mock_cancel.assert_not_called()
+        mock_submit.assert_not_called()
+        reloaded = store.get_document(profile.id, note.id)
+        assert reloaded.metadata.get("extraction_status") == "done"
+    finally:
+        config_module.clear_settings_cache()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,11 +95,11 @@ async def test_resume_upload_applies_llm_overrides(client, monkeypatch):
                 "/api/resume/upload",
                 files={"file": ("resume.txt", b"John Doe\nSoftware Engineer", "text/plain")},
                 data={
-                    "flash_model": "openai/gpt-5.3-codex",
+                    "flash_model": "localhost/openai/gpt-5.3-codex",
                     "reasoning_effort": "medium",
                     "api_keys_json": json.dumps({"openai": "sk-test"}),
                     "providers_json": json.dumps({
-                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                        "flash": {"base_url": "https://example.test/v1"}
                     }),
                 },
             )
@@ -146,11 +146,11 @@ async def test_paste_resume(client, monkeypatch):
                 "/api/resume/paste",
                 json={
                     "content": "John Doe\nSoftware Engineer",
-                    "flash_model": "openai/gpt-5.3-codex",
+                    "flash_model": "custom/openai/gpt-5.3-codex",
                     "reasoning_effort": "medium",
                     "api_keys": {"openai": "sk-test"},
                     "providers": {
-                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                        "flash": {"base_url": "https://example.test/v1"}
                     },
                 },
             )
@@ -263,7 +263,7 @@ async def test_profile_document_upload_forwards_llm_overrides(client, monkeypatc
                     "reasoning_effort": "medium",
                     "api_keys_json": json.dumps({"openai": "sk-test"}),
                     "providers_json": json.dumps({
-                        "flash": {"provider": "custom", "base_url": "https://example.test/v1"}
+                        "flash": {"base_url": "https://example.test/v1"}
                     }),
                 },
             )
@@ -335,7 +335,6 @@ async def test_re_extract_profile_forwards_llm_overrides(client, monkeypatch, tm
                     "api_keys": {"openai": "sk-test"},
                     "providers": {
                         "flash": {
-                            "provider": "custom",
                             "base_url": "https://example.test/v1",
                         },
                     },
@@ -418,7 +417,6 @@ async def test_synthesize_profile_applies_llm_overrides(client, monkeypatch, tmp
                     "api_keys": {"openai": "sk-test"},
                     "providers": {
                         "embedding": {
-                            "provider": "custom",
                             "base_url": "https://example.test/v1",
                         },
                     },
@@ -465,8 +463,8 @@ def test_build_overrides_maps_scoped_custom_base_urls():
         embedding_model="openai/text-embedding-3-small",
         api_keys={"openai": "sk-test"},
         providers={
-            "flash": server_module.ProviderOverride(provider="custom", base_url="https://example.test/v1"),
-            "embedding": server_module.ProviderOverride(provider="custom", base_url="https://embed.example.test/v1"),
+            "flash": server_module.ProviderOverride(base_url="https://example.test/v1"),
+            "embedding": server_module.ProviderOverride(base_url="https://embed.example.test/v1"),
         },
         filter_thresholds={"vector": 0.5},
     )
@@ -483,6 +481,42 @@ def test_build_overrides_maps_scoped_custom_base_urls():
     }
 
 
+def test_build_overrides_normalizes_legacy_custom_paths_and_maps_anthropic_bases():
+    req = server_module.OptimizeRequest(
+        resume_checksum="resume-checksum",
+        job_text="Product manager role",
+        pro_model="custom/anthropic/claude-sonnet-4-5",
+        flash_model="localhost/openai/gpt-5.4-mini",
+        providers={
+            "pro": server_module.ProviderOverride(base_url="https://anthropic-proxy.example.test"),
+            "flash": server_module.ProviderOverride(base_url="https://openai-proxy.example.test/v1"),
+        },
+    )
+
+    overrides = server_module._build_overrides(req)
+
+    assert req.pro_model == "anthropic/claude-sonnet-4-5"
+    assert req.flash_model == "openai/gpt-5.4-mini"
+    assert overrides["pro_model"] == "anthropic/claude-sonnet-4-5"
+    assert overrides["flash_model"] == "openai/gpt-5.4-mini"
+    assert overrides["pro_anthropic_api_base"] == "https://anthropic-proxy.example.test"
+    assert overrides["flash_openai_api_base"] == "https://openai-proxy.example.test/v1"
+
+
+def test_build_overrides_rejects_custom_base_url_for_unsupported_provider():
+    req = server_module.OptimizeRequest(
+        resume_checksum="resume-checksum",
+        job_text="Product manager role",
+        flash_model="gemini/gemini-2.5-flash",
+        providers={
+            "flash": server_module.ProviderOverride(base_url="https://example.test/v1"),
+        },
+    )
+
+    with pytest.raises(ValueError, match="Custom base URL is supported only"):
+        server_module._build_overrides(req)
+
+
 def test_normalize_optimization_error_for_custom_provider_none_type_failure():
     req = server_module.OptimizeRequest(
         resume_checksum="resume-checksum",
@@ -492,7 +526,6 @@ def test_normalize_optimization_error_for_custom_provider_none_type_failure():
         embedding_model="openai/text-embedding-3-small",
         providers={
             "flash": server_module.ProviderOverride(
-                provider="custom",
                 base_url="http://127.0.0.1:8317/v1",
             ),
         },
@@ -505,6 +538,23 @@ def test_normalize_optimization_error_for_custom_provider_none_type_failure():
 
     message = server_module._normalize_optimization_error(exc, req)
 
-    assert "Custom OpenAI-compatible provider request failed before the model returned a usable response" in message
+    assert "Custom provider request failed before the model returned a usable response" in message
     assert "flash: http://127.0.0.1:8317/v1" in message
     assert "openai/gpt-5.4, openai/gpt-5.3-codex, openai/text-embedding-3-small" in message
+
+
+@pytest.mark.asyncio
+async def test_optimize_rejects_legacy_custom_prefix_without_base_url(client):
+    source = ResumeSource(content="resume text", first_name="Jane", last_name="Doe")
+    with patch("hr_breaker.server.ResumeCache.get", return_value=source):
+        resp = await client.post(
+            "/api/optimize",
+            json={
+                "resume_checksum": "resume-checksum",
+                "job_text": "Product manager role",
+                "flash_model": "localhost/openai/gpt-5.4-mini",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "Use `openai/<model>`" in resp.json()["error"]


### PR DESCRIPTION
## Summary

- **Editable profile notes** — PATCH endpoint to update note title/content with no-op detection (skips re-extraction when nothing changed)
- **Selective extraction** — `POST /api/profile/{id}/extract` now accepts optional `doc_ids` list; only specified docs get re-extracted
- **Extract failed button** — UI button to retry only pending/error/empty documents
- **Live extraction status** — badges show "extracting" while docs are actively being processed
- **Shared LLM provider** — single `LLM_SHARED_PROVIDER` / `LLM_SHARED_API_KEY` / `LLM_SHARED_BASE_URL` config as fallback for all OpenAI-compatible model scopes

## Testing

- All 58 relevant tests pass (server, profile_store, config_override)
- Manual testing of note editing, extract buttons, and status badges
- Pre-existing extractor test failure unrelated to these changes